### PR TITLE
Fix list mailto: links to correctly be <name>@lists.open-mpi.org

### DIFF
--- a/community/lists/functions.inc
+++ b/community/lists/functions.inc
@@ -23,7 +23,7 @@ function print_list($name) {
     printf("<P><CENTER>\n");
     red("YOU MUST BE SUBSCRIBED IN ORDER TO POST TO THE LIST");
     printf("<br /\n>");
-    print_mailto("open-mpi.org", $name, "$name at lists dash open dash mpi dot org");
+    print_mailto("lists.open-mpi.org", $name, "$name at lists dot open dash mpi dot org");
     printf("<br /\n>");
     red("YOU MUST BE SUBSCRIBED IN ORDER TO POST TO THE LIST");
     printf("</center></p>\n\n");


### PR DESCRIPTION
Fix list mailto: links to correctly be <name>@lists.open-mpi.org