### PR TITLE
licence: fix link to point to 3-clause BSD license

### DIFF
--- a/community/license.php
+++ b/community/license.php
@@ -7,8 +7,8 @@ include_once("$topdir/includes/curl_get.inc");
 ?>
 
 <p><strong>Open MPI is distributed under the <?php
-print("<a href=\"http://www.opensource.org/licenses/bsd-license.php\">");
-?>New BSD license</a>, listed below.</strong>
+print("<a href=\"https://opensource.org/licenses/BSD-3-Clause\">");
+?>3-clause BSD license</a>, listed below.</strong>
 
 <?php
 $str = do_curl_get("https://raw.githubusercontent.com/open-mpi/ompi/master/LICENSE");


### PR DESCRIPTION
We've always distributed Open MPI under the 3-clause BSD license and
showed the right text of the license on the web site; we just had the
link accidentally pointing to 2-clause BSD license on opensource.org.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>