### PR TITLE
htaccess: stop always adding www to URL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,8 +23,8 @@ Deny from 180.211.180.14
 <IfModule mod_rewrite.c>
 RewriteEngine on
 
-## Redirect everyone to https://www.open-mpi.org (vs. open-mpi.org)
-RewriteCond %{HTTP_HOST} !^www\. [NC]
+## Redirect everyone from open-mpi.org to https://wwww.open-mpi.org
+RewriteCond %{HTTP_HOST} ^open-mpi.org [NC]
 RewriteRule ^ https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
 ## Redirect everyone from http:// to https://


### PR DESCRIPTION
Change the rewrite rule that was intended to redirect visitors
from open-mpi.org to www.open-mpi.org to be pickier about the
origin URL, so that it only redirects from open-mpi.org and not
from other URLs (such as aws.open-mpi.org).  This allows the
tree to be usable from home directories on aws.open-mpi.org,
which is great for testing before pushing to prod.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>