### PR TITLE
ompi-packagers: make it print link to mail-archive

### DIFF
--- a/community/lists/ompi-packagers/index.php
+++ b/community/lists/ompi-packagers/index.php
@@ -1,0 +1,2 @@
+<?php
+header("Location: ..");


### PR DESCRIPTION
Make a subdirectory named ompi-packagers so that it prints a link out
to the mail-archive.com archive of this list.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>