### PR TITLE
Re-release Open MPI 3.0.2rc1

### DIFF
--- a/software/ompi/v3.0/version.inc
+++ b/software/ompi/v3.0/version.inc
@@ -15,7 +15,7 @@ $releases = array("3.0.1", "3.0.0");
 /* prereleases must be ordered newest to oldest.  All prereleases
    will be shown, so make an empty array when the official release
    is added to releases above */
-$prereleases = array();
+$prereleases = array("3.0.2rc1");
 
 /* set to true if we should add a cygwin note */
 $cygwin_note = 0;


### PR DESCRIPTION
In the tarball move to S3, looks like I accidently "unreleased"
Open MPI 3.0.2rc1.  Add it to the release list.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>