### PR TITLE
Use unauthenticated S3 access for mirrors

### DIFF
--- a/includes/downloads.inc
+++ b/includes/downloads.inc
@@ -15,8 +15,10 @@ use Aws\Exception\AwsException;
 if (strpos(gethostname(), 'hostgator.com') !== false) {
     $provider = CredentialProvider::ini("default", "/home2/ompiteam/.aws/credentials");
     $provider = CredentialProvider::memoize($provider);
-} else {
+} elseif ($_SERVER['SERVER_NAME'] == 'aws.open-mpi.org') {
     $provider = CredentialProvider::defaultProvider();
+} else {
+    $provider = false;
 }
 
 function prettyprint_filesize($size) {


### PR DESCRIPTION
We were trying to use the default provider (which was looking
for creds somewhere) rather than no provider when on mirror
sites, which broke the download list.  If we're not on a host
that should have creds (currently, *.open-mpi.org hosts), just
use anon access.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>