### PR TITLE
sitewide notice: effectively disable the lists.open-mpi.org notice

### DIFF
--- a/sitewide_notice.inc
+++ b/sitewide_notice.inc
@@ -6,8 +6,8 @@ if (function_exists("date_default_timezone_set")) {
 }
 
 # Display this notice until 8:00am US Eastern time, Monday, Jun 6, 2016
-#if (time() < mktime(8, 0, 0, 6, 6, 2016)) {
-?>
+if (time() < mktime(8, 0, 0, 6, 6, 2016)) {
+>
 <div align=center>
 
 <strong>
@@ -28,5 +28,5 @@ if (function_exists("date_default_timezone_set")) {
 
 </div>
 <?
-#}
+}
 ?>


### PR DESCRIPTION
lists.open-mpi.org is back, so disable the sitewide notice.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>