### PR TITLE
faq/mpi-removed: fix --enable-mpi1-compatibility flag typo

### DIFF
--- a/faq/mpi-removed.inc
+++ b/faq/mpi-removed.inc
@@ -114,7 +114,7 @@ symbols.
 All that being said, if you are unable to immediately update your
 application to stop using these removed MPI-1 symbols, you can
 re-enable them in [mpi.h] by configuring Open MPI with the
-[--enable-mpi-compatibility] flag.
+[--enable-mpi1-compatibility] flag.
 
 *NOTE:* Future releases of Open MPI beyond the v4.0.x series may
 remove these symbols altogether.";


### PR DESCRIPTION
In one of the FAQs in mpi-removed.inc, it refers to the compatibility flag as `--enable-mpi-compatibility` instead of `--enable-mpi1-compatibility`. Is that a typo? It [didn't work for me](https://github.com/Homebrew/homebrew-core/pull/34973#issuecomment-446274306) when I tried it, where `--enable-mpi1-compatibility` did.