### PR TITLE
Remove busted "strong>" tag dropping in doc/index.php

### DIFF
--- a/doc/index.php
+++ b/doc/index.php
@@ -34,7 +34,7 @@ color=red><?php
 This documentation reflects the latest progression in the 3.1.x series.
 <strong><font color=red>This code base is still supported, but is 
 in "bug fix only" mode.</font></strong>
-strong></li>
+</li>
 
 <li><a href="v3.0/"><strong>v3.0 series
 </strong></a>.  This documentation reflects


### PR DESCRIPTION
On the current website, this is rendering as:

<img width="700" alt="screen shot 2018-12-11 at 7 33 13 pm" src="https://user-images.githubusercontent.com/2618447/49839123-bee0ac00-fd7b-11e8-92ac-9c58344539d1.png">

Note the extra "strong>" showing up at the end of the line.

This PR cleans that up.