### PR TITLE
Typo and style fixes for faq/sm.inc

### DIFF
--- a/faq/sm.inc
+++ b/faq/sm.inc
@@ -10,7 +10,7 @@ mechanism for transferring data between two processes via shared memory.
 This BTL can only be used between processes executing on the same node.
 
 Beginning with the v1.8 series, the [vader] BTL replaces the [sm] BTL unless
-the local system lacks the required support or the user specifically request
+the local system lacks the required support or the user specifically requests
 the latter be used. At this time, [vader] requires CMA support which is typically
 found in more current kernels. Thus, systems based on older kernels may default
 to the slower [sm] BTL.";
@@ -43,12 +43,12 @@ $a[] = "Typically, it is unnecessary to do so;  OMPI will use the best BTL avail
 for each communication.
 
 Nevertheless, you may use the MCA parameter [btl].  You should also specify the
-[self] BTL for communications between a process and itself.  Further, if not all
+[self] BTL for communications between a process and itself.  Furthermore, if not all
 processes in your job will run on the same, single node, then you also need
 to specify a BTL for internode communications.  For example:
 
 <geshi bash>
-shell$ mpirun <font color=red>--mca btl self,sm,tcp</font> -np 16 ./a.out
+shell$ mpirun --mca btl self,sm,tcp -np 16 ./a.out
 </geshi>";
 
 /////////////////////////////////////////////////////////////////////////
@@ -104,8 +104,8 @@ $a[] = "The [ompi_info] command can display all the parameters available for the
 [sm] BTL and [sm] mpool:
 
 <geshi bash>
-shell$ ompi_info <font color=red><strong>--param  btl  sm</strong></font>
-shell$ ompi_info <font color=red><strong>--param mpool sm</strong></font>
+shell$ ompi_info --param  btl  sm
+shell$ ompi_info --param mpool sm
 </geshi>";
 
 /////////////////////////////////////////////////////////////////////////
@@ -122,10 +122,10 @@ performance for memory.
 <ul>
 <li> [btl_sm_eager_limit]:
 If message data plus header information fits within this limit, the
-message is sent \"eagerly\"... &mdash; that is, a sender attempts to write
+message is sent \"eagerly\" &mdash; that is, a sender attempts to write
 its entire message to shared buffers without waiting for a receiver to
 be ready.  Above this size, a sender will only write the first part of
-a message, then wait for the receiver to acknowledge its ready before
+a message, then wait for the receiver to acknowledge its readiness before
 continuing.  Eager sends _can_ improve performance by decoupling
 senders from receivers.</li>
 
@@ -140,7 +140,7 @@ process.  By default, there is only one FIFO per process.
 Conceivably, if many senders are all sending to the same process and
 contending for a single FIFO, there will be congestion.  If there are
 many FIFOs, however, the receiver must poll more FIFOs to find
-in-coming messages.  Therefore, you might try increasing this
+incoming messages.  Therefore, you might try increasing this
 parameter slightly if you have _many_ (at least dozens) of processes
 all sending to the same process.  For example, if 100 senders are all
 contending for a single FIFO for a particular receiver, it may suffice
@@ -149,7 +149,7 @@ to increase [btl_sm_num_fifos] from 1 to 2.</li>
 <li> [btl_sm_fifo_size]:
 Starting in Open MPI v1.3.2, FIFOs could no longer grow.  If you
 believe the FIFO is getting congested because a process falls far
-behind in reading in in-coming message fragments, increase this size
+behind in reading incoming message fragments, increase this size
 manually.</li>
 
 <li> [btl_sm_free_list_num]:
@@ -170,7 +170,7 @@ $q[] = "Where is the file that sm will mmap in?";
 $anchor[] = "where-sm-file";
 
 $a[] = "The file will be in the OMPI session directory, which is typically
-something like [/tmp/openmpi-sessions-<i>myusername</i>@<i>mynodename</i>*] .
+something like [/tmp/openmpi-sessions-<i>myusername</i>@<i>mynodename</i>/*] .
 The file itself will have the name
 [shared_mem_pool].<i>mynodename</i>.  For example, the full path could be
 [/tmp/openmpi-sessions-myusername@node0_0/1543/1/shared_mem_pool.node0].
@@ -186,7 +186,7 @@ $anchor[] = "poor-sm-btl-performance";
 
 $a[] = "The most common problem with the shared memory BTL is when the
 Open MPI session directory is placed on a network filesystem (e.g., if
-[/tmp] is not a local disk).  This is because the shared memory BTL
+[/tmp] is not on a local disk).  This is because the shared memory BTL
 places a memory-mapped file in the Open MPI session directory (see <a
 href=\"#where-sm-file\">this entry</a> for more details).  If the
 session directory is located on a network filesystem, the shared
@@ -197,7 +197,7 @@ MPI session directory to a local filesystem.
 
 Some users have reported success and possible performance
 optimizations with having [/tmp] mounted as a \"tmpfs\" filesystem
-(i.e., a RAM-based filesystem).  However, before doing configuring
+(i.e., a RAM-based filesystem).  However, before configuring
 your system this way, be aware of a few items:
 
 <ol>
@@ -225,7 +225,7 @@ $q[] = "Can I use SysV instead of mmap?";
 
 $anchor[] = "SysV-vs-mmap";
 
-$a[] = "In the 1.3 and 1.4 Open MPI series, shared memory is established
+$a[] = "In the v1.3 and v1.4 Open MPI series, shared memory is established
 via [mmap].  In future releases, there _may_ be an option for using SysV
 shared memory.";
 
@@ -241,7 +241,7 @@ lifetime of your job.  Shared-memory allocations (for FIFOs and
 fragment free lists) will be made in this area.  Here, we look at the
 size of that shared-memory area.
 
-If you want just one, hard number, then go with approximately 128
+If you want just one hard number, then go with approximately 128
 Mbytes per node per job, shared by all the job's processes on that
 node.  That is, an OMPI job will need more than a few Mbytes per node,
 but typically less than a few Gbytes.
@@ -255,7 +255,7 @@ sized thusly:
 nbytes = n * mpool_sm_per_peer_size
 if ( nbytes < mpool_sm_min_size ) nbytes = mpool_sm_min_size
 if ( nbytes > mpool_sm_max_size ) nbytes = mpool_sm_max_size
-</gesih>
+</geshi>
 
 where [n] is the number of processes in the job running on that
 particular node and the [mpool_sm_*] are MCA parameters.  For small
@@ -311,7 +311,7 @@ Beyond that, you might _want_ additional shared memory for performance
 reasons, so that FIFOs and fragment lists can grow if your program's
 message traffic encounters resource congestion.  Even if there is no
 room to grow, however, your correctly written MPI program should still
-run to complete in the face of congestion; performance simply degrades
+run to completion in the face of congestion; performance simply degrades
 somewhat.  Note that while shared-memory resources can grow after
 [MPI_Init()], they cannot shrink.
 
@@ -328,10 +328,10 @@ You need approximately the total of:
 <li> max fragments: &nbsp;&nbsp;&nbsp; [n &times; btl_sm_free_list_num &times; btl_sm_max_send_size]
 </ul>
 
-where
+where:
 <ul>
 <li> [n] is the number of MPI processes in your job on the node
-<li> [pagesize] is the OS page size (4K for Linux and 8K for Solaris)
+<li> [pagesize] is the OS page size (4KB for Linux and 8KB for Solaris)
 <li> [btl_sm_*] are MCA parameters
 </ul>";
 
@@ -346,9 +346,9 @@ $a[] = "There are two parts to this question.
 
 First, how does one reduce how big the [mmap] file is?  The answer is:
 <ul>
-<li> up to Open MPI v1.3.1:  reduce [mpool_sm_per_peer_size], [mpool_sm_min_size],
+<li> Up to Open MPI v1.3.1:  Reduce [mpool_sm_per_peer_size], [mpool_sm_min_size],
      and [mpool_sm_max_size]
-<li> starting with Open MPI v1.3.2:  reduce [mpool_sm_min_size]
+<li> Starting with Open MPI v1.3.2:  Reduce [mpool_sm_min_size]
 </ul>
 
 Second, how does one reduce how much shared memory is needed?  (Just
@@ -364,10 +364,10 @@ start up.)  The answers are:
 <li> For large values of [n] &mdash; that is, for many processes per node &mdash; there
      are two cases:
      <ul>
-     <li> up to Open MPI v1.3.1:  shared-memory usage is dominated by the
+     <li> Up to Open MPI v1.3.1:  Shared-memory usage is dominated by the
           FIFOs, which consume a certain number of pages.  Usage is
           high and cannot be reduced much via MCA parameter tuning.
-     <li> starting with Open MPI v1.3.2:  shared-memory usage is dominated
+     <li> Starting with Open MPI v1.3.2:  Shared-memory usage is dominated
           by the eager free lists.  So, you can reduce the MCA parameter
           [btl_sm_eager_limit].
      </ul>


### PR DESCRIPTION
In particular, this PR removes some embedded HTML tags inside `<geshi>` blocks, which are not actually supported and end up getting rendered literally, which isn't the intent. E.g., this ain't right:

<img width="577" alt="screen shot 2018-12-11 at 8 13 03 pm" src="https://user-images.githubusercontent.com/2618447/49840394-32d18300-fd81-11e8-8cb8-36098074a23e.png">


Also fixes a busted "`</gesih>`" tag which is causing this misrendering:

<img width="893" alt="screen shot 2018-12-11 at 8 07 30 pm" src="https://user-images.githubusercontent.com/2618447/49840365-13d2f100-fd81-11e8-9abd-7ea1217b7e97.png">

In the lists near the bottom of the page, I added initial capitals for parallelism, and because the list item contents are (I think) really complete sentences, in the imperative voice.