### PR TITLE
Migrate ompi_bug() function to GitHub Issues

### DIFF
--- a/faq/bug-functions.inc
+++ b/faq/bug-functions.inc
@@ -8,6 +8,6 @@ function sun_bug($num) {
 }
 
 function ompi_bug($num) {
-    return "<a href=\"https://svn.open-mpi.org/trac/ompi/ticket/$num\">";
+    return "<a href=\"https://github.com/open-mpi/ompi/issues/$num\">";
 }
 

--- a/faq/openfabrics.inc
+++ b/faq/openfabrics.inc
@@ -1891,7 +1891,8 @@ functions often.  The default is 1, meaning that early completion
 optimization semantics are enabled (because it can reduce
 point-to-point latency).
 
-See Open MPI " . ompi_bug(1224) . "ticket #1224</a> for further
+See Open MPI <a href="https://svn.open-mpi.org/trac/ompi/ticket/1224">
+legacy Trac ticket #1224</a> for further
 information.
 
 $note This FAQ entry only applies to the v1.2 series.  This


### PR DESCRIPTION
It looks like the current Open MPI issue tracker has been migrated from the old Trac system to GitHub issues, so the FAQ `ompi_bug()` function should probably point to GitHub issues.

This PR changes `ompi_bug()` to point to GitHub issues, and replaces the single usage of it for Trac bug 1224 with a hardcoded URL to the old Trac system, since it doesn't seem like that particular bug got migrated over (probably because it was closed before the migration happened).