### PR TITLE
Typo and style fixes for faq/perftools.inc

### DIFF
--- a/faq/perftools.inc
+++ b/faq/perftools.inc
@@ -52,7 +52,7 @@ settings you have chosen, etc.  In many cases, it makes most sense for
 you just to distinguish between time spent inside MPI from time spent
 outside MPI.
 
-Elapsed wallclock time will probably be your key metric.  Exactly how
+Elapsed wall clock time will probably be your key metric.  Exactly how
 the MPI implementation spends time waiting is less important.";
 
 /////////////////////////////////////////////////////////////////////////
@@ -82,9 +82,9 @@ diagnostic information for certain MPI calls, etc.
 
 OMPI generally layers the various function interfaces as follows:
 <ul>
-<li> Fortran [MPI_] interfaces are weak symbols for ...
-<li> Fortran [PMPI_] interfaces, which call ...
-<li> C [MPI_] interfaces, which are weak symbols for ...
+<li> Fortran [MPI_] interfaces are weak symbols for...
+<li> Fortran [PMPI_] interfaces, which call...
+<li> C [MPI_] interfaces, which are weak symbols for...
 <li> C [PMPI_] interfaces, which provide the specified functionality.
 </ul>
 
@@ -110,8 +110,8 @@ href=\"http://www.mpi-forum.org/docs/mpi22-report/node312.htm#Node312\">"
 
 /////////////////////////////////////////////////////////////////////////
 
-$q[] = "Should I use those switches --enable-mpi-profile and
---enable-trace when I configure OMPI?";
+$q[] = "Should I use those switches <code>--enable-mpi-profile</code> and
+<code>--enable-trace</code> when I configure OMPI?";
 
 $anchor[] = "configure-switches";
 
@@ -148,7 +148,7 @@ Unfortunately, PERUSE didn't win standardization, so it didn't really
 go anywhere.  Open MPI may drop PERUSE support at some point in the
 future.
 
-MPI-3 standardised the MPI_T tools interface API (see Chapter 14 in
+MPI-3 standardized the MPI_T tools interface API (see Chapter 14 in
 the MPI-3.0 specification).  MPI_T is fully supported starting with
 v1.7.3.
 
@@ -207,9 +207,9 @@ As such, debugging tools can help you step through or pry into the
 execution of your MPI program.  Popular tools include " . "<a
 href=\"http://www.totalviewtech.com\">" . "TotalView</a>, which can be
 downloaded for free trial use, and " . "<a
-href=\"http://www.allinea.com/?page=48\">" . "Allinea DDT</a> which
+href=\"https://www.arm.com/products/development-tools/server-and-hpc/forge/ddt\">" . "Arm DDT</a> which
 also provides evaluation copies.
 
 The command-line job inspection tool " . "<a
 href=\"http://padb.pittman.org.uk\">" . "padb</a> has been ported to
-ORTE and OMPI";
+ORTE and OMPI.";


### PR DESCRIPTION
* Minor typo and style fixes.

* Uses American-style "-ize" instead of UK-style "-ise", since that seems to be dominant within the repo already:

```
$ grep --exclude 'community/lists/*' -r standardize * | wc -l 
      13
$ grep --exclude 'community/lists/*' -r standardise * | wc -l  
       1
```

* Updates the link for Allinea DDT, which is now called Arm DDT and has a different URL.