### PR TITLE
Typo and style fixes for faq/osx.inc

### DIFF
--- a/faq/osx.inc
+++ b/faq/osx.inc
@@ -8,18 +8,18 @@ $anchor[] = "filesystems";
 
 $a[] = "Generally, Open MPI does not care whether it is running from
 an HFS+ or UFS filesystem.  However, the C++ wrapper compiler historically
-has been called <code>mpiCC</code>, which of course is the same file
-as <code>mpicc</code> when running on HFS+.  During the <code>configure</code>
+has been called [mpiCC], which of course is the same file
+as [mpicc] when running on case-insensitive HFS+.
+During the [configure]
 process, Open MPI will attempt to determine if the build filesystem is
 case sensitive or not, and assume the install file system is the same
 way.  Generally, this is all that is needed to deal with HFS+.
 
 However, if you are building on UFS and installing to HFS+, you should
-specify <code>--without-cs-fs</code> to configure to make sure Open
-MPI does not build the <code>mpiCC</code> wrapper.  Likewise, if you
+specify [--without-cs-fs] to [configure] to make sure Open
+MPI does not build the [mpiCC] wrapper.  Likewise, if you
 build on HFS+ and install to UFS, you may want to specify
-<code>--with-cs-fs</code> to ensure that <code>mpiCC</code> is
-installed.
+[--with-cs-fs] to ensure that [mpiCC] is installed.
 ";
 
 /////////////////////////////////////////////////////////////////////////
@@ -30,20 +30,21 @@ $anchor[] = "xcode";
 
 $a[] = "
 XCode has a non-public interface for adding compilers to XCode.  A
-friendly Open MPI user sent in configuration file for XCode 2.3,
-<A HREF=\"MPICC.pbcompspec\">MPICC.pbcompspec</A>, which will add
+friendly Open MPI user sent in a configuration file for XCode 2.3
+(<a href=\"MPICC.pbcompspec\">MPICC.pbcompspec</a>), which will add
 support for the Open MPI wrapper compilers.  The file should be
-placed in <code>/Library/Application Support/Apple/Developer Tools/Specifications/</code>.  Upon starting XCode, this file is loaded and added to the list of
+placed in [/Library/Application Support/Apple/Developer Tools/Specifications/].
+Upon starting XCode, this file is loaded and added to the list of
 known compilers.
 
-To use the <code>mpicc</code> compiler, open the project, get info on the
+To use the [mpicc] compiler: open the project, get info on the
 target, click the rules tab, and add a new entry.  Change the process rule
-for \"C source files\" and select using MPICC.
+for \"C source files\" and select \"using MPICC\".
 
-Before moving the file, the <code>ExecPath</code> parameter should be set
-to the location of the Open MPI install.  The <code>BasedOn</code> parameter
-should be updated to refer to the compiler version that <code>mpicc</code>
-will invoke &mdash; generally <code>gcc-4.0</code> on OS X 10.4 machines.
+Before moving the file, the [ExecPath] parameter should be set
+to the location of the Open MPI install.  The [BasedOn] parameter
+should be updated to refer to the compiler version that [mpicc]
+will invoke &mdash; generally [gcc-4.0] on OS X 10.4 machines.
 
 Thanks to Karl Dockendorf for this information.
 ";
@@ -100,7 +101,7 @@ on the Open MPI user's mailing list:
 Since Open MPI 1.1.2, we also support authentication using Kerberos.
 The process is essentially the same, but there is no need to specify
 the XGRID_PASSWORD field.  Open MPI applications will then run as
-the authenticated user, rather than <code>nobody</code>.
+the authenticated user, rather than [nobody].
 ";
 
 /////////////////////////////////////////////////////////////////////////
@@ -111,7 +112,7 @@ $anchor[] = "xgrid-more-info";
 
 $a[] = "Please write to us on the <a href=\"$topdir/community/lists/ompi.php\">user's mailing list</a>.  Hopefully any
 replies that we send will contain enough information to create proper
-FAQ's about how to use Open MPI with XGrid.";
+FAQs about how to use Open MPI with XGrid.";
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -119,19 +120,19 @@ $q[] = "Is Open MPI included in OS X?";
 
 $anchor[] = "osx-bundled-ompi";
 
-$a[] = "Open MPI v1.2.3 was included in some older versions of OS X &mdash;
+$a[] = "Open MPI v1.2.3 was included in some older versions of OS X,
 starting with version 10.5 (Leopard).  It was removed in more recent
 versions of OS X (we're not sure in which version it disappeared &mdash;
 *but your best bet is to simply <a href=\"$topdir/software/\">download
 a modern version of Open MPI</a> for your modern version of OS X*).
 
-Note, however, that the Leopard does not include a Fortran compiler,
+Note, however, that OS X Leopard does not include a Fortran compiler,
 so the OS X-shipped version of Open MPI does not include Fortran
 support.
 
 If you need/want Fortran support, you will need to build your own copy
 of Open MPI (assumedly when you have a Fortran compiler installed).
-The Open MPI team strongly recomends *not* overwriting the OS
+The Open MPI team strongly recommends *not* overwriting the OS
 X-installed version of Open MPI, but rather installing it somewhere
 else (e.g., [/opt/openmpi]).";
 
@@ -147,11 +148,11 @@ new version, etc.
 
 If you wish to use a community version of Open MPI, You can download
 and build Open MPI on OS X just like any other supported platform.  We
-*strongly* recomend *not* replacing the OS X-installed Open MPI, but
+*strongly* recommend *not* replacing the OS X-installed Open MPI, but
 rather installing to an alternate location (such as [/opt/openmpi]).
 
 Once you successfully install Open MPI, <a
-href=\"?category=running#run-prereqs\">ensure to prefix your [PATH]
+href=\"?category=running#run-prereqs\">be sure to prefix your [PATH]
 with the bindir of Open MPI</a>.  This will ensure that you are using
 your newly-installed Open MPI, not the OS X-installed Open MPI.  For
 example:
@@ -171,7 +172,7 @@ shell$ ompi_info
 [...see output from newly-installed Open MPI...]
 </geshi>
 
-Of course, you'll want to make your [PREFIX] changes permanent.  One
+Of course, you'll want to make your [PATH] changes permanent.  One
 way to do this is to <a
 href=\"?category=running#adding-ompi-to-path\">edit your shell startup
 files</a>.
@@ -203,7 +204,7 @@ $q[] = "I am using Open MPI 2.0.x / v2.1.x and getting an error at application s
 
 $anchor[] = "startup-errors-with-open-mpi-2.0.x";
 
-$a[] = "On some versions of Mac OS X / MacOS Sierra, the default
+$a[] = "On some versions of Mac OS X / macOS Sierra, the default
 temporary directory location is sufficiently long that it is easy for
 an application to create file names for temporary files which exceed
 the maximum allowed file name length.  With Open MPI v2.0.x, this can lead to
@@ -229,5 +230,5 @@ something shorter in length.
 </geshi>
 
 The workaround for the Open MPI 2.0.x and v2.1.x release series is to set the
-[TMPDIR] environment variable to [/tmp] or other short directory
+[TMPDIR] environment variable to [/tmp] or another short directory
 name.";


### PR DESCRIPTION
Notable changes:

* Replaces all the `<code>...</code>`s with `[...]` in answers
* Styles "MacOS" as "macOS", matching Apple's styling