### PR TITLE
Fix papers styling

### DIFF
--- a/papers/aosa-vol-2/data.inc
+++ b/papers/aosa-vol-2/data.inc
@@ -1,7 +1,7 @@
 <?php
 $title = "The Architecture of Open Source Applications, volume 2";
 
-$overview = "Chapter 15 presents an architectural overview of Open MPI.";
+$overview = "Chapter 15 presents an architectural overview of Open MPI";
 
 $presented = "<a href=\"http://www.aosabook.org/en/index.html\">
 Book web site</a>";

--- a/papers/euro-pvmmpi-2004-overview/data.inc
+++ b/papers/euro-pvmmpi-2004-overview/data.inc
@@ -1,6 +1,6 @@
 <?php 
 $title = "Open MPI: Goals, Concept, and Design of a Next Generation MPI Implementation";
-$overview = "Presents an overview of the Open MPI project.";
+$overview = "Presents an overview of the Open MPI project";
 
 $authors = "Edgar Gabriel, Graham E. Fagg, George Bosilca, Thara Angskun,
 Jack J. Dongarra, Jeffrey M. Squyres, Vishal Sahay, Prabhanjan Kambadur,

--- a/papers/euro-pvmmpi-2006-hpc-protocols/data.inc
+++ b/papers/euro-pvmmpi-2006-hpc-protocols/data.inc
@@ -1,6 +1,6 @@
 <?php 
 $title = "High Performance RDMA Protocols in HPC";
-$overview = "An overview of Open MPI's RDMA-based point-to-point messaging layer (PML).";
+$overview = "An overview of Open MPI's RDMA-based point-to-point messaging layer (PML)";
 
 $authors = "Galen Mark Shipman, Tim S. Woodall, George Bosilca, 
 Rich L. Graham, Arthur B. Maccabe";

--- a/papers/euro-pvmmpi-2007-ib/data.inc
+++ b/papers/euro-pvmmpi-2007-ib/data.inc
@@ -2,7 +2,7 @@
 $title = "Investigations on InfiniBand: Efficient Network Buffer Utilization at Scale";
 
 $overview = "Using multiple queue pairs and pre-posted buffer sizes to
-get more efficient registered memory utilization.";
+get more efficient registered memory utilization";
 
 $presented = "<a href=\"http://pvmmpi07.lri.fr/\">" .
 "EuroPVM/MPI '07</a>, September 30th - October 3rd, 2007, Paris,

--- a/papers/euro-pvmmpi-2007-mtt/data.inc
+++ b/papers/euro-pvmmpi-2007-mtt/data.inc
@@ -3,7 +3,7 @@
 $title = "An Extensible Framework for Distributed Testing of MPI
 Implementations";
 
-$overview = "An overview of the MPI Testing Tool (MTT).";
+$overview = "An overview of the MPI Testing Tool (MTT)";
 
 $presented = "<a href=\"http://pvmmpi07.lri.fr/\">" .
 "EuroPVM/MPI '07</a>, September 30th - October 3rd, 2007, Paris,

--- a/papers/ics-2004/data.inc
+++ b/papers/ics-2004/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "The Component Architecture of Open MPI: Enabling Third-Party Collective Algorithms";
-$overview = "General description of the MPI Component Architecture, focusing on the details of the collective algorithm framework in Open MPI.";
+$overview = "General description of the MPI Component Architecture, focusing on the details of the collective algorithm framework in Open MPI";
 
 $authors = "Jeffrey M. Squyres, Andrew Lumsdaine";
 

--- a/papers/index.php
+++ b/papers/index.php
@@ -70,21 +70,26 @@ general architecture papers:</B><BR>
 <p><strong>2018</strong></p>
 <ul>
 <?php
-print_papers(array("sc-2018"));
+print_papers(array("sc-2018"
+                   ));
 ?>
 </ul>
 
 <p><strong>2017</strong></p>
 <ul>
 <?php
-print_papers(array("sc-2017", "sc-2017-pmix"));
+print_papers(array("sc-2017",
+                   "sc-2017-pmix"
+                   ));
 ?>
 </ul>
 
 <p><strong>2016</strong></p>
 <ul>
 <?php
-print_papers(array("sc-2016", "sc-2016-pmix"));
+print_papers(array("sc-2016",
+                   "sc-2016-pmix"
+                   ));
 ?>
 </ul>
 
@@ -93,7 +98,8 @@ print_papers(array("sc-2016", "sc-2016-pmix"));
 <?php
 print_papers(array("sc-2015",
                    "sc-2015-pmix",
-                   "versioning-update-2015"));
+                   "versioning-update-2015"
+                   ));
 ?>
 </ul>
 
@@ -101,7 +107,7 @@ print_papers(array("sc-2015",
 <UL>
 <?php
 print_papers(array("sc-2014"
-		   ));
+                   ));
 ?>
 </UL>
 
@@ -109,7 +115,7 @@ print_papers(array("sc-2014"
 <UL>
 <?php
 print_papers(array("sc-2013"
-		   ));
+                   ));
 ?>
 </UL>
 
@@ -117,8 +123,8 @@ print_papers(array("sc-2013"
 <UL>
 <?php
 print_papers(array("sc-2012",
-		   "aosa-vol-2"
-		   ));
+                   "aosa-vol-2"
+                   ));
 ?>
 </UL>
 
@@ -126,7 +132,7 @@ print_papers(array("sc-2012",
 <UL>
 <?php
 print_papers(array("sc-2011",
-		   "euro-mpi-2011-ompio"
+                   "euro-mpi-2011-ompio"
                    ));
 ?>
 </UL>
@@ -151,7 +157,7 @@ print_papers(array("sc-2009",
 <UL>
 <?php
 print_papers(array("sc-2008",
-	           ));
+                   ));
 ?>
 </UL>
 
@@ -159,8 +165,9 @@ print_papers(array("sc-2008",
 <UL>
 <?php
 print_papers(array("euro-pvmmpi-2007-mtt",
-		   "isc-2007",
-                   "kicc-2007"));
+                   "isc-2007",
+                   "kicc-2007"
+                   ));
 ?>
 </UL>
 
@@ -168,8 +175,9 @@ print_papers(array("euro-pvmmpi-2007-mtt",
 <UL>
 <?php
 print_papers(array("sc-2006",
-	           "euro-pvmmpi-2006-hpc-protocols",
-                   "workshop-2006"));
+                   "euro-pvmmpi-2006-hpc-protocols",
+                   "workshop-2006"
+                   ));
 ?>
 </UL>
 
@@ -179,7 +187,7 @@ print_papers(array("sc-2006",
 print_papers(array("sc-2005",
                    "euro-pvmmpi-2005-orte",
                    "ppam-2005",
-		   ));
+                   ));
 ?>
 </UL>
 
@@ -187,9 +195,12 @@ print_papers(array("sc-2005",
 <UL>
 <?php
 print_papers(array("euro-pvmmpi-2004-overview",
-                   "ics-2004"));
+                   "ics-2004"
+                   ));
 ?>
 <UL>
 
 <?php
 include_once("$topdir/includes/footer.inc");
+
+?>

--- a/papers/kicc-2007/data.inc
+++ b/papers/kicc-2007/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Efficient Message Passing on Multi-Clusters: An IPv6 Extension to Open MPI";
-$overview = "General description and first benchmarks of the Open MPI IPv6 extension.";
+$overview = "General description and first benchmarks of the Open MPI IPv6 extension";
 
 $authors = "Christian Kauhaus, Adrian Knoth, Thomas Peiselt, Dietmar Fey";
 

--- a/papers/papers.inc
+++ b/papers/papers.inc
@@ -37,9 +37,9 @@ function paper_page($title, $authors, $presented, $abstract, $files, $mon, $day,
                         $name = "Postscript";
                     } else if ($match[0] == ".pdf" || $match[0] == ".PDF") {
                         $name = "PDF";
-                    } else if ($match[0] == ".doc" || $match[0] == ".doc") {
+                    } else if ($match[0] == ".doc" || $match[0] == ".DOC") {
                         $name = "Microsoft Word";
-                    } else if ($match[0] == ".ppt" || $match[0] == ".PPT" || $match[0] == ".pptx") {
+                    } else if ($match[0] == ".ppt" || $match[0] == ".PPT" || $match[0] == ".pptx" || $match[0] == ".PPTX") {
                         $name = "Microsoft Powerpoint";
                     } else {
                         $name = $files[$i];

--- a/papers/ppam-2005/data.inc
+++ b/papers/ppam-2005/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Open MPI: A Flexible High Performance MPI";
-$overview = "Overview of Open MPI and the OB1 point-to-point architecture.";
+$overview = "Overview of Open MPI and the OB1 point-to-point architecture";
 
 $presented = "PPAM 2005, the 6th International Conference on Parallel
 Processing and Applied Mathematics in Poznan, Poland, in September

--- a/papers/sc-2005/data.inc
+++ b/papers/sc-2005/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Supercomputing 2005 slides";
-$overview = "Slides from various presentations about Open MPI or by the Open MPI team members.";
+$overview = "Slides from various presentations about Open MPI or by the Open MPI team members";
 
 $authors = "Jeff Squyres, Tim Woodall, George Bosilca, Graham Fagg";
 

--- a/papers/sc-2006/data.inc
+++ b/papers/sc-2006/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Supercomputing 2006 slides";
-$overview = "Slides from various presentations about Open MPI or by the Open MPI team members.";
+$overview = "Slides from various presentations about Open MPI or by the Open MPI team members";
 
 
 $authors = "Brian Barrett, George Bosilca, Josh Hursey, Rainer Keller, Tim Mattox, Jeff Squyres";

--- a/papers/sc-2008/data.inc
+++ b/papers/sc-2008/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Supercomputing 2008 slides";
-$overview = "Slides from various presentations about Open MPI or by the Open MPI team members.";
+$overview = "Slides from various presentations about Open MPI or by the Open MPI team members";
 
 $authors = "George Bosilca, Joshua Hursey, Rainer Keller, Matthias Mueller, Jeff Squyres";
 

--- a/papers/sc-2009/data.inc
+++ b/papers/sc-2009/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Supercomputing 2009 slides";
-$overview = "Slides from various presentations about Open MPI or by the Open MPI team members.";
+$overview = "Slides from various presentations about Open MPI or by the Open MPI team members";
 
 $authors = "George Bosilca, Joshua Hursey, Jeff Squyres, Tim Mattox, Rich Graham";
 

--- a/papers/sc-2010/data.inc
+++ b/papers/sc-2010/data.inc
@@ -1,6 +1,6 @@
 <?php
 $title = "Supercomputing 2010 slides";
-$overview = "Slides from various presentations about Open MPI or by the Open MPI team members.";
+$overview = "Slides from various presentations about Open MPI or by the Open MPI team members";
 
 $authors = "George Bosilca, Jeff Squyres, Brice Goglin";
 


### PR DESCRIPTION
The big change in this: it changes the visible `papers/*/data.inc` files to consistently *not* use a period at the end of `$overview`. This is appropriate because they are sentence fragments, not complete sentences.

Compare to how they are rendered now: despite the fact that they are (almost) all sentence fragments, some of them end with a period, and some of them don't.

<img width="1360" alt="screen shot 2018-12-12 at 5 48 01 am" src="https://user-images.githubusercontent.com/2618447/49864943-9f746e00-fdd1-11e8-9a94-147340a65ff4.png">

This PR will make the styling in `papers/` more consistent. (The one or two that are full sentences, I still removed the period from, for visual consistency.)

This PR also:
* Fixes a bug in `papers/papers.inc` where it messes up the case for ".DOC" and forgets the upper-case ".PPTX" variant
* Tidies up the indentation and code formatting in `papers/index.php`, without changing the actual content