### PR TITLE
Add a website doco directory?

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@ Options -Indexes -MultiViews +FollowSymLinks
 ## We likes our Tumblebeasts
 ErrorDocument 404 /404.php
 
-## make sure nobody gets the htaccess files
+## Make sure nobody gets the htaccess files
 <Files ~ "^[\._]ht">
     Order allow,deny
     Deny from all
@@ -19,13 +19,13 @@ ErrorDocument 404 /404.php
     Satisfy All
 </Files>
 
-## make sure no one gets to the .git dir
+## Make sure no one gets to the .git dir
 RedirectMatch 404 /\.git
 
 ## Anyone remember what this was from?
 Deny from 180.211.180.14
 
-# with build artifacts in S3, latest_snapshot.txt is a
+# With build artifacts in S3, latest_snapshot.txt is a
 # PHP script that generates the right answer, so turn
 # on PHP processing for those files.
 <Files "latest_snapshot.txt">
@@ -49,7 +49,7 @@ RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 RewriteRule ^MailArchives/(.*)$  /community/lists/$1 [L,R=301]
 RewriteRule ^(.+)(\.php|\.html)/$  /$1$2 [R=301,L]
 
-# redirect requests for nightly tarballs / nightly latest_snapshot.txt requests
+# Redirect requests for nightly tarballs / nightly latest_snapshot.txt requests
 # to download.open-mpi.org.
 RewriteRule software/(.*)/nightly/(.*)/(latest_snapshot\.txt|.*\.tar\.gz|.*\.tar\.bz2) https://download.open-mpi.org/nightly/$1/$2/$3 [L,R=302]
 RewriteRule nightly/(.*)/(latest_snapshot\.txt|.*\.tar\.gz|.*\.tar\.bz2) https://download.open-mpi.org/nightly/open-mpi/$1/$2 [L,R=302]

--- a/.htaccess
+++ b/.htaccess
@@ -19,6 +19,13 @@ ErrorDocument 404 /404.php
     Satisfy All
 </Files>
 
+## Don't let anyone look at the internal site doco, either
+<Files ~ "doc-www">
+    Order allow,deny
+    Deny from all
+    Satisfy All
+</Files>
+
 ## Make sure no one gets to the .git dir
 RedirectMatch 404 /\.git
 

--- a/doc-www/README.txt
+++ b/doc-www/README.txt
@@ -1,0 +1,93 @@
+doc-www README.txt
+====================
+
+This doc-www/ directory contains documentation about the `ompi-www` website itself. This stuff
+is for developers who wish to work on maintaining the website, as opposed to people who just
+want to learn about Open MPI.
+
+
+# Hosting Requirements
+
+This section describes what what you need to run the ompi-www site.
+
+You need:
+
+* A PHP-enabled web server
+* PHP 7.x
+
+Run the web server with its content root pointed at the ompi-www repo checkout
+or distribution installation location.
+
+## Example: Running the Site Locally on macOS
+
+For example, to run the ompi-www site locally on macOS to test your local changes:
+
+Install Apache HTTPD and PHP. If you're using Homebrew , do `brew install httpd php`,
+and follow the directions in the `php` Caveats to set it up with Apache HTTPD.
+
+Edit Apache's `/usr/local/etc/httpd/httpd.conf` to point a VirtualHost at your
+repo checkout. For example, if your repo checkout is at `~/local/repos/ompi-www`:
+
+```
+Listen 8081
+<VirtualHost *:8081>
+    ServerAdmin me@example.com
+
+    DocumentRoot /Users/me/local/repos/ompi-www
+    <Directory />
+        Options FollowSymLinks
+        AllowOverride All
+        Allow from all
+        Require all granted
+        Satisfy All
+    </Directory>
+
+    <FilesMatch \.php$>
+        SetHandler application/x-httpd-php
+    </FilesMatch>
+
+    DirectoryIndex index.php index.html
+</VirtualHost>
+```
+
+Then do `brew services start php; brew services start httpd` to fire up the HTTPD,
+and head to http://localhost:8081 in a web browser.
+
+# Local Site Tools
+
+Despite it being called `doc-www`, this directory contains a `bin/` subdirectory with executable
+tools that you can run on a Unix system for exploring this repo.
+
+##  grep-variants
+
+Usage: grep-variants [text-a] [text-b]
+
+Counts how many occurrences there are of each of two text variants in this site (excluding
+the mailing list archives). This is for giving you guidance on which of two style options to
+use, like for deciding between "email" and "e-mail" or "segfault" and "seg fault"
+
+It only works if you run it from the repo root directory.
+
+It's imperfect because it doesn't take in to account line wrapping and extra hyphenation and whatnot.
+
+Example:
+
+```
+$ ./doc-www/bin/grep-variants email e-mail
+Variant A: email
+     151
+Variant B: e-mail
+      15
+$ ./doc-www/bin/grep-variants segfault "seg fault"
+Variant A: segfault
+       3
+Variant B: seg fault
+      10
+$ ./doc-www/bin/grep-variants Unix unix UNIX
+Variant A: Unix
+     296
+Variant B: unix
+      50
+Variant C: UNIX
+     421
+```

--- a/doc-www/Style-Guide.md
+++ b/doc-www/Style-Guide.md
@@ -1,0 +1,73 @@
+ompi-www Style Guide
+===========================
+
+This is a brief Style Guide for code and prose to be included on the Open MPI web site
+(which is contained in this `ompi-www` repo).
+
+
+# Code Style
+
+## HTML and PHP Style
+
+* Manually hard-wrap lines at about 80 characters
+
+## HTML Style
+
+* Tag and attribute names in lower case
+* Otherwise, do whatever works, I guess
+
+## PHP Style
+
+* Avoid PHP warnings that will show up in the web server logs.
+
+
+# Prose Style
+
+## Typesetting Conventions
+
+Code-like things are set in fixed width font, using `<code>...</code>` in regular HTML
+and `[...]` in FAQ answers:
+
+* Code things
+  * Literal code snippets
+  * Command names
+  * File names and paths
+  * MCA parameter names
+  * Environment variables
+  * Stuff like that
+
+Not in bold or italics or double-quotes; fixed-width font.
+
+Use bold for emphasis, or names of things that have particular technical meaning, but aren't code snippets or command names per se. Italics is fine for emphasis, too.
+
+Use em dashes, surrounded by spaces, wherever a dash (as opposed to a hyphen) is needed. Use an `&mdash;` HTML entity to get these in HTML, rather than a literal Unicode em dash character (which is hard to read in a text editor using fixed-width font).
+
+## Style and Usage
+
+* Use Oxford commas.
+* American style, not British style.
+  * "-ize", not "-ise"
+* "different than" is fine; you don't have to stick to "different from".
+* Use "i.e." and "e.g." correctly.
+  * "i.e." means "that is" — fully explains the referent
+  * "e.g." means "for example" — gives one or a few examples of something
+* Respect other brands' stylings.
+  * "GitHub", not "Github"  
+* Don't bother putting explicit trademark notations like "(R)" or "®" or "™".
+* In lists, periods at the ends of items that are full sentences; no periods at the end of items that are sentence fragments
+  * Nice-looking parallelism takes precedence over this rule.
+
+## Spellings and Capitalizations
+
+* "Open MPI", not "OpenMPI" or "Open-MPI"
+  * "OMPI" is an acceptable abbreviation when addressing the Open MPI developer
+    community. For user-facing docs, stick with "Open MPI".
+  * It is not styled in fixed-width or italics or anything special like that.
+* When referring to Open MPI versions or series, use "vX.Y" or "vX.Y.Z", instead of "version X.Y" or "version vX.Y".
+* "UNIX", not "Unix"
+
+And these are some provisional ones based on usage counts from `grep-variants`; they are not
+consistently used throughout the code base yet:
+
+* "seg fault", not "segfault"
+* "email", not "e-mail"

--- a/doc-www/bin/grep-variants
+++ b/doc-www/bin/grep-variants
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# grep-variants: a little script to compare frequency of text variants
+# within this repo
+#
+# Usage:
+#
+# ./doc-www/bin/grep-variants <a> <b> [<c>] [<d>] [<e>]
+
+a="$1"
+b="$2"
+c="$3"
+d="$4"
+e="$5"
+
+echo "Variant A: $a"
+grep --exclude 'community/lists/*' -r "$a" * | wc -l 
+echo "Variant B: $b"
+grep --exclude 'community/lists/*' -r "$b" * | wc -l 
+if [[ -n "$c" ]]; then
+  echo "Variant C: $c"
+  grep --exclude 'community/lists/*' -r "$c" * | wc -l 
+fi
+if [[ -n "$d" ]]; then
+  echo "Variant D: $d"
+  grep --exclude 'community/lists/*' -r "$d" * | wc -l 
+fi
+if [[ -n "$e" ]]; then
+  echo "Variant E: $e"
+  grep --exclude 'community/lists/*' -r "$e" * | wc -l 
+fi


### PR DESCRIPTION
What do you think about adding a `doc-www/` directory with documentation and tools for the `ompi-www` website itself?

The Style Guide file in this PR is based on the prevailing usage I've observed in the existing `ompi-www` code base.