### PR TITLE
Update URL for TotalView in faq/perftools.inc

### DIFF
--- a/faq/perftools.inc
+++ b/faq/perftools.inc
@@ -205,7 +205,7 @@ generally understanding the behavior of your program.
 
 As such, debugging tools can help you step through or pry into the
 execution of your MPI program.  Popular tools include " . "<a
-href=\"http://www.totalviewtech.com\">" . "TotalView</a>, which can be
+href=\"https://www.roguewave.com/products-services/totalview\">" . "TotalView</a>, which can be
 downloaded for free trial use, and " . "<a
 href=\"http://www.allinea.com/?page=48\">" . "Allinea DDT</a> which
 also provides evaluation copies.


### PR DESCRIPTION
Fixes #179.

Updates the link for TotalView to a currently-working URL. Manual inspection of the new website sure looks like it's the same product.