### PR TITLE
Re-style "SLURM" as "Slurm" to match Slurm project's current branding

### DIFF
--- a/faq/building.inc
+++ b/faq/building.inc
@@ -1162,11 +1162,11 @@ _Last supported in the v1.6.x series._ </li>
 
 /////////////////////////////////////////////////////////////////////////
 
-$q[] = "How do I build Open MPI with support for SLURM / XGrid?";
+$q[] = "How do I build Open MPI with support for Slurm / XGrid?";
 
 $anchor[] = "build-rte";
 
-$a[] = "SLURM support is built automatically; there is nothing that
+$a[] = "Slurm support is built automatically; there is nothing that
 you need to do.
 
 XGrid support is built automatically if the XGrid tools are installed.";

--- a/faq/categories.inc
+++ b/faq/categories.inc
@@ -105,8 +105,8 @@ $parent_name[] = "";
     $names[] = "tm";
     $parent_name[] = "run_parent";
 
-    $titles[] = "Running jobs under SLURM";
-    $short_titles[] = "SLURM";
+    $titles[] = "Running jobs under Slurm";
+    $short_titles[] = "Slurm";
     $names[] = "slurm";
     $parent_name[] = "run_parent";
 

--- a/faq/large-clusters.inc
+++ b/faq/large-clusters.inc
@@ -30,7 +30,7 @@ and can significantly reduce startup time.</li>
 </ul>
 
 Other options are available when launching via [mpirun] or when launching using
-the native resource manager launcher (e.g., [srun] in a SLURM environment).
+the native resource manager launcher (e.g., [srun] in a Slurm environment).
 These are activated by setting the corresponding MCA parameter, and include:
 
 <ul>

--- a/faq/openfabrics.inc
+++ b/faq/openfabrics.inc
@@ -660,7 +660,7 @@ startup scripts are located (e.g., [/etc/profile] and
 [/etc/csh.cshrc])</li>
 </ul>
 
-Also, note that resource managers such as SLURM, Torque/PBS, LSF,
+Also, note that resource managers such as Slurm, Torque/PBS, LSF,
 etc. may affect OpenFabrics jobs in two ways:
 
 <ol>
@@ -683,10 +683,10 @@ you typically need to modify daemons' startup scripts to increase the
 limit before they drop root privliedges.
 
 <li> Some resource managers can limit the amount of locked
-memory that is made available to jobs.  For example, SLURM has some
-fine-grained controls that allow locked memory for _only_ SLURM jobs
-(i.e., the system's default is low memory lock limits, but SLURM jobs
-can get high memory lock limits).  See these FAQ items on the SLURM
+memory that is made available to jobs.  For example, Slurm has some
+fine-grained controls that allow locked memory for _only_ Slurm jobs
+(i.e., the system's default is low memory lock limits, but Slurm jobs
+can get high memory lock limits).  See these FAQ items on the Slurm
 web site for more details: " .
 "<a href=\"http://www.llnl.gov/linux/slurm/faq.html#rlimit\">" .
 "propagating limits</a> and " .

--- a/faq/running.inc
+++ b/faq/running.inc
@@ -287,7 +287,7 @@ shell$ mpirun --prefix /opt/openmpi-$ver_current -np 4 a.out
 This will prefix the [PATH] and [LD_LIBRARY_PATH] on both the local
 and remote hosts with [/opt/openmpi-$ver_current/bin] and
 [/opt/openmpi-$ver_current/lib], respectively.  This is _usually_
-unnecessary when using resource managers to launch jobs (e.g., SLURM,
+unnecessary when using resource managers to launch jobs (e.g., Slurm,
 Torque, etc.) because they tend to copy the entire local environment
 &mdash; to include the [PATH] and [LD_LIBRARY_PATH] &mdash; to remote nodes
 before execution.  As such, if [PATH] and [LD_LIBRARY_PATH] are set
@@ -367,7 +367,7 @@ entry") . ".
 
 Note, however, that not all environments require a hostfile.  For
 example, Open MPI will automatically detect when it is running in
-batch / scheduled environments (such as SGE, PBS/Torque, SLURM, and
+batch / scheduled environments (such as SGE, PBS/Torque, Slurm, and
 LoadLeveler), and will use host information provided by those systems.
 
 Also note that if using a launcher that requires a hostfile and no
@@ -438,7 +438,7 @@ other MPI implementations, [--machinefile] is a synonym for
 hosts on which to run on the command line.  See "
 . faqlink("#mpirun-host", "this FAQ entry") . " for more information
 about the [--host] option.</li>
-<li> If you are running in a scheduled environment (e.g., in a SLURM,
+<li> If you are running in a scheduled environment (e.g., in a Slurm,
 Torque, or LSF job), Open MPI will automatically get the lists of
 hosts from the scheduler.</li>
 </ol>
@@ -513,7 +513,7 @@ remotehost
 
 If you are unable to launch across multiple hosts, check that your SSH
 keys are setup properly.  Or, if you are running in a managed
-environment, such as in a SLURM, Torque, or other job launcher, check
+environment, such as in a Slurm, Torque, or other job launcher, check
 that you have reserved enough hosts, are running in an allocated job,
 etc.</li>
 
@@ -852,7 +852,7 @@ Hostfiles works in two different ways:
 
 <li> *Exclusionary:* If a list of hosts to run on has been provided by
 another source (e.g., by a hostfile or a batch scheduler such as
-SLURM, PBS/Torque, SGE, etc.), the hosts provided by the hostfile must
+Slurm, PBS/Torque, SGE, etc.), the hosts provided by the hostfile must
 be in the already-provided host list.  If the hostfile-specified nodes
 are _not_ in the already-provided host list, [mpirun] will abort
 without launching anything.
@@ -958,7 +958,7 @@ specify on which hosts to launch MPI processes.
 
 <li> *Exclusionary:* If a list of hosts to run on has been provided by
 another source (e.g., by a hostfile or a batch scheduler such as
-SLURM, PBS/Torque, SGE, etc.), the hosts provided by the [--host] option
+Slurm, PBS/Torque, SGE, etc.), the hosts provided by the [--host] option
 must be in the already-provided host list.  If the [--host]-specified
 nodes are _not_ in the already-provided host list, [mpirun] will abort
 without launching anything.
@@ -1060,7 +1060,7 @@ processors are available on a given host.
 
 The default number of slots on any machine, if not explicitly
 specified, is 1 (e.g., if a host is listed in a hostfile by has no
-corresponding \"slots\" keyword).  Schedulers (such as SLURM,
+corresponding \"slots\" keyword).  Schedulers (such as Slurm,
 PBS/Torque, SGE, etc.) automatically provide an accurate default slot
 count.
 
@@ -1408,7 +1408,7 @@ the most up-to-date information, but as of v1.0, Open MPI supports:
 <li> PBS Pro, Torque, and Open PBS</li>
 <li> LoadLeveler scheduler (full support since 1.1.1)</li>
 <li> rsh / ssh</li>
-<li> SLURM</li>
+<li> Slurm</li>
 <li> LSF</li>
 <li> XGrid (discontinued starting with OMPI 1.4)</li>
 <li> Yod (Cray XT-3 and XT-4)</li>
@@ -1424,7 +1424,7 @@ $a[] = "See <a href=\"./?category=rsh#rsh-not-ssh\">this FAQ entry</a>.";
 
 /////////////////////////////////////////////////////////////////////////
 
-$q[] = "How do I run with the SLURM and PBS/Torque launchers?";
+$q[] = "How do I run with the Slurm and PBS/Torque launchers?";
 
 $anchor[] = "run-slurm-or-tm";
 
@@ -1435,7 +1435,7 @@ automatically detect when it is running inside such jobs and will just
 \"do the Right Thing.\"
 
 See <a href=\"?category=slurm#slurm-run-jobs\">this FAQ entry</a> for
-a description of how to run jobs in SLURM; see <a
+a description of how to run jobs in Slurm; see <a
 href=\"?category=tm#tm-run-jobs\">this FAQ entry</a> for a description
 of how to run jobs in PBS/Torque.";
 

--- a/faq/slurm.inc
+++ b/faq/slurm.inc
@@ -1,7 +1,7 @@
 <?php
 include_once("$topdir/software/ompi/current/version.inc");
 
-$q[] = "How do I run jobs under SLURM?";
+$q[] = "How do I run jobs under Slurm?";
 
 $anchor[] = "slurm-run-jobs";
 
@@ -12,42 +12,42 @@ your application using srun if OMPI is configured per
 href=\"?category=slurm#slurm-direct-srun-mpi-apps\">this FAQ entry</a>.
 
 The longer answer is that Open MPI supports launching parallel jobs in
-all three methods that SLURM supports:
+all three methods that Slurm supports:
 
 <ol>
-<li> Launching via \"[salloc ...]\": supported (older versions of SLURM used \"[srun -A ...]\")</li>
-<li> Launching via \"[sbatch ...]\": supported (older versions of SLURM used \"[srun -B ...]\")</li>
+<li> Launching via \"[salloc ...]\": supported (older versions of Slurm used \"[srun -A ...]\")</li>
+<li> Launching via \"[sbatch ...]\": supported (older versions of Slurm used \"[srun -B ...]\")</li>
 <li> Launching via \"[srun -n X my_mpi_application]\"</li>
 </ol>
 
 Specifically, you can launch Open MPI's [mpirun] in an interactive
-SLURM allocation (via the [salloc] command) or you can submit a
-script to SLURM (via the [sbatch] command), or you can \"directly\"
+Slurm allocation (via the [salloc] command) or you can submit a
+script to Slurm (via the [sbatch] command), or you can \"directly\"
 launch MPI executables via [srun].
 
 Open MPI automatically obtains both the list of hosts and how many
-processes to start on each host from SLURM directly.  Hence, it is
+processes to start on each host from Slurm directly.  Hence, it is
 unnecessary to specify the [--hostfile], [--host], or [-np] options to
-[mpirun].  Open MPI will also use SLURM-native mechanisms to launch
+[mpirun].  Open MPI will also use Slurm-native mechanisms to launch
 and kill processes ([rsh] and/or [ssh] are not required).
 
 For example:
 
 <geshi bash>
-# Allocate a SLURM job with 4 nodes
+# Allocate a Slurm job with 4 nodes
 shell$ salloc -N 4 sh
-# Now run an Open MPI job on all the nodes allocated by SLURM
+# Now run an Open MPI job on all the nodes allocated by Slurm
 # (Note that you need to specify -np for the 1.0 and 1.1 series;
-# the -np value is inferred directly from SLURM starting with the
+# the -np value is inferred directly from Slurm starting with the
 # v1.2 series)
 shell$ mpirun my_mpi_application
 </geshi>
 
 This will run the 4 MPI processes on the nodes that were allocated by
-SLURM.  Equivalently, you can do this:
+Slurm.  Equivalently, you can do this:
 
 <geshi bash>
-# Allocate a SLURM job with 4 nodes and run your MPI application in it
+# Allocate a Slurm job with 4 nodes and run your MPI application in it
 shell$ salloc -N 4 mpirun my_mpi_aplication
 </geshi>
 
@@ -79,16 +79,16 @@ support was built and use it in place of PMI-1.";
 
 /////////////////////////////////////////////////////////////////////////
 
-$q[] = "I use SLURM on a cluster with the OpenFabrics network stack.  Do I need to do anything special?";
+$q[] = "I use Slurm on a cluster with the OpenFabrics network stack.  Do I need to do anything special?";
 
 $anchor[] = "slurm-with-ofed";
 
-$a[] = "Yes.  You need to ensure that SLURM sets up the locked memory
+$a[] = "Yes.  You need to ensure that Slurm sets up the locked memory
 limits properly.  Be sure to see <a
 href=\"?category=openfabrics#ib-locked-pages\">this FAQ entry about
 locked memory</a> and <a
 href=\"?category=openfabrics#ib-locked-pages-more\">this FAQ entry for
-references about SLURM</a>.";
+references about Slurm</a>.";
 
 /////////////////////////////////////////////////////////////////////////
 

--- a/faq/supported-systems.inc
+++ b/faq/supported-systems.inc
@@ -161,7 +161,7 @@ ORTE currently natively supports the following run-time environments:
 <li> LSF </li>
 <li> POE (pre-1.8 only)</li>
 <li> rsh / ssh</li>
-<li> SLURM</li>
+<li> Slurm</li>
 <li> XGrid (pre-1.3 only)</li>
 <li> Yod (Red Storm, pre-1.5 only)</li>
 </ul>

--- a/faq/sysadmin.inc
+++ b/faq/sysadmin.inc
@@ -36,7 +36,7 @@ $anchor[] = "multiple-installs";
 $a[] = "Yes and no.
 
 Open MPI can handle a variety of different run-time environments
-(e.g., rsh/ssh, SLURM, PBS, etc.) and a variety of different
+(e.g., rsh/ssh, Slurm, PBS, etc.) and a variety of different
 interconnection networks (e.g., ethernet, Myrinet, Infiniband, etc.)
 in a single installation.  Specifically: because Open MPI is
 fundamentally powered by a component architecture, plug-ins for all


### PR DESCRIPTION
The Slurm project is now styling their name as "Slurm" instead of the all-caps "SLURM". How about updating the Open MPI doco to match their styling?