### PR TITLE
source/building: Only center the tables; not the prose

### DIFF
--- a/source/building.php
+++ b/source/building.php
@@ -61,6 +61,7 @@ developers working on the internals of Open MPI itself</em>):
 </TR>
 
 </TABLE>
+</CENTER>
 
 <P>The following table lists the versions that are used to make
 nightly snapshot and official release Open MPI tarballs.  Other
@@ -86,6 +87,7 @@ YMMV when using verions older than those listed below --
 compilers</em>.  Using older versions is unsupported.  If you run into
 problems, upgrade to at least the versions listed below.</p>
 
+<CENTER>
 <TABLE BORDER=1 CELLPADDING=5>
 <TR>
 <TH>Open MPI Release</TH>


### PR DESCRIPTION
In `source/building.php`, the current centering logic centers some of the paragraphs of prose in addition to the two tables. For readability, maybe only the tables should be centered, leaving all the prose left-justified like normal?

This PR restricts the scope of the `<CENTER>`ing so that only the tables are centered, and the middle prose paragraphs are left-justified.