### PR TITLE
404.php: Simplify image base URL (so it works on non-default ports)

### DIFF
--- a/404.php
+++ b/404.php
@@ -11,8 +11,7 @@
 // in this file.
 
 $script_base = dirname($_SERVER["SCRIPT_NAME"]);
-$image_base_url = "https://" .
-	$_SERVER["SERVER_NAME"] . $script_base . "/images";
+$image_base_url = "/images";
 ?>
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">


### PR DESCRIPTION
When running the web page on a non-default port (such as when testing changes locally), the 404 page presents with broken image links.

<img width="478" alt="screen shot 2018-12-15 at 2 06 01 pm" src="https://user-images.githubusercontent.com/2618447/50046542-f482df00-0072-11e9-8b43-98a5e5cdf6dd.png">

This is because the port number is not included in the constructed image base URL.

How about simplifying the image base URL to just `/images`, interpreted by the browser as relative to the root of the server it's on, so the images work on non-default ports, too?

