### PR TITLE
Fix missing variables in MTT definitions

### DIFF
--- a/software/mtt/current/version.inc
+++ b/software/mtt/current/version.inc
@@ -10,20 +10,27 @@
 # "version.inc" in it that contains a definition of at least 2
 # variables:
 #
-# $ver_{$dir}: a full version number string indicating the complete
+# Then fill in per-version info variables:
+#
+# $ver_{version}: a full version number string indicating the complete
 # name of this version.  Examples: "0.9b1", "1.0.2", "2.0".
 #
-# $ver_{$dir}_dir: the name of the directory in the URL where the
+# $ver_{version}_dir: the name of the directory in the URL where the
 # tree for this version exists.  This should be under
 # $topdir/software/.  Examples: "v0.9", "v1.0", "v1.1", "v2.0".
 #
-# {version} is a variable-friendly transmorgification of the directory
+# Where:
+#
+# {version} is a variable-friendly transmogrification of the directory
 # name, meaning "replace . with _".
 #
 $dir = "v3.0";
 
+$ver_v3_0 = "3.0";
+$ver_v3_0_dir = "v3.0";
+
 # Note that we do not include $dir/version.inc here (like other Open
-# MPI proejcts) because MTT does not have downloadable tarballs.
+# MPI projects) because MTT does not have downloadable tarballs.
 #include_once("$topdir/software/mtt/$dir/version.inc");
 
 $name = preg_replace("/\./", "_", $dir);
@@ -32,4 +39,3 @@ $str = "\$ver_current = \$ver_$name;";
 eval($str);
 $str = "\$ver_current_dir = \$ver_${name}_dir;";
 eval($str);
-


### PR DESCRIPTION
There are a couple missing variables in the MTT `version.inc` file. This causes the following PHP warnings on the MTT page:

<img width="1071" alt="screen shot 2018-12-15 at 2 23 50 pm" src="https://user-images.githubusercontent.com/2618447/50046672-11201680-0075-11e9-9dca-af09e4b33df7.png">


This PR fixes them.