### PR TITLE
Fix missing variables in OTPO definitions

### DIFF
--- a/software/otpo/current/version.inc
+++ b/software/otpo/current/version.inc
@@ -10,17 +10,20 @@
 # "version.inc" in it that contains a definition of at least 2
 # variables:
 #
-# $ver_{$dir}: a full version number string indicating the complete
+# $ver_{version}: a full version number string indicating the complete
 # name of this version.  Examples: "0.9b1", "1.0.2", "2.0".
 #
-# $ver_{$dir}_dir: the name of the directory in the URL where the
+# $ver_{version}_dir: the name of the directory in the URL where the
 # tree for this version exists.  This should be under
 # $topdir/software/.  Examples: "v0.9", "v1.0", "v1.1", "v2.0".
 #
-# {version} is a variable-friendly transmorgification of the directory
+# {version} is a variable-friendly transmogrification of the directory
 # name, meaning "replace . with _".
 #
 $dir = "v1.0";
+
+$ver_v1_0 = "v1.0";
+$ver_v1_0_dir = "v1.0";
 
 # This part is automatic and should get the variables and stuff them
 # into $current_ver and $current_ver_dir.
@@ -31,4 +34,3 @@ $str = "\$ver_current = \$ver_$name;";
 eval($str);
 $str = "\$ver_current_dir = \$ver_${name}_dir;";
 eval($str);
-


### PR DESCRIPTION
Just like #210, but for the OTPO version definitions.