### PR TITLE
Remove "individual"/"corporate" Contribute sub-items

### DIFF
--- a/community/contribute/nav.inc
+++ b/community/contribute/nav.inc
@@ -2,5 +2,3 @@
 include_once("$topdir/includes/nav.inc");
 
 $this_dir = "contribute";
-$this_nav[] = new Nav("Individual contributor", "individual.php");
-$this_nav[] = new Nav("Corporate contributor", "corporate.php");


### PR DESCRIPTION
These pages just redirect back to the main Contribute page, so
may as well remove them from the nav bar. The actual page files are
still there so no existing links will break.
