### PR TITLE
Add HPC and "high performance computing" to meta keywords

### DIFF
--- a/includes/http_header.inc
+++ b/includes/http_header.inc
@@ -13,7 +13,7 @@ print("<META name=\"keywords\" content=\"");
 if (isset($meta_keywords)) {
     print($meta_keywords);
 } else {
-    print("MPI, Open MPI, Open-MPI, OpenMPI, parallel computing, beowulf, linux, cluster, parallel, distributed");
+    print("MPI, Open MPI, Open-MPI, OpenMPI, parallel computing, HPC, high performance computing, beowulf, linux, cluster, parallel, distributed");
 }
 print("\">\n");
 ?>


### PR DESCRIPTION
"HPC" is one of the core topic terms for what Open MPI does, right? Maybe we should add it to the site's meta keywords.