### PR TITLE
Fix "<?php" tags for sitewide notice

### DIFF
--- a/includes/header.inc
+++ b/includes/header.inc
@@ -271,7 +271,7 @@ printbutton("");
         <TR>
           <TD>
           <!-- BEGIN MAIN TEXT -->
-<?
+<?php
 if (file_exists("$topdir/sitewide_notice.inc")) {
   include("$topdir/sitewide_notice.inc");
 }

--- a/sitewide_notice.inc
+++ b/sitewide_notice.inc
@@ -1,5 +1,5 @@
-<?
-# Required as of PHP 5.1 -- see 
+<?php
+# Required as of PHP 5.1 -- see
 # http://us2.php.net/manual/en/function.mktime.php
 if (function_exists("date_default_timezone_set")) {
     date_default_timezone_set('America/Indiana/Indianapolis');
@@ -27,6 +27,6 @@ if (time() < mktime(8, 0, 0, 6, 6, 2016)) {
 <hr width=50%>
 
 </div>
-<?
+<?php
 }
 ?>


### PR DESCRIPTION
It looks like the Sitewide Notice is not actually working, due to a couple malformed `<?php` tags.

This PR fixes it.