### PR TITLE
.htaccess: updates from the live site

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -39,26 +39,50 @@ RewriteEngine on
 
 ## Redirect everyone from open-mpi.org to https://wwww.open-mpi.org
 RewriteCond %{HTTP_HOST} ^open-mpi.org [NC]
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule ^ https://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
 ## Redirect everyone from http:// to https://
 RewriteCond %{HTTPS} !=on
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
 
 ## These probably aren't necessary any more
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule ^MailArchives/(.*)$  /community/lists/$1 [L,R=301]
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule ^(.+)(\.php|\.html)/$  /$1$2 [R=301,L]
 
 # redirect requests for nightly tarballs / nightly latest_snapshot.txt requests
 # to download.open-mpi.org.
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule software/(.*)/nightly/(.*)/(latest_snapshot\.txt|.*\.tar\.gz|.*\.tar\.bz2) https://download.open-mpi.org/nightly/$1/$2/$3 [L,R=302]
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule nightly/(.*)/(latest_snapshot\.txt|.*\.tar\.gz|.*\.tar\.bz2) https://download.open-mpi.org/nightly/open-mpi/$1/$2 [L,R=302]
 
 # Redirect requests for release artifacts to download.open-mpi.org
 RewriteCond %{REQUEST_URI} !latest_snapshot.txt$ [NC]
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule software/ompi/(.*)/downloads/(.*) https://download.open-mpi.org/release/open-mpi/$1/$2 [L,R=301]
 
 RewriteCond %{REQUEST_URI} !latest_snapshot.txt$ [NC]
+RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/cpanel-dcv/[0-9a-zA-Z_-]+$
+RewriteCond %{REQUEST_URI} !^/\.well-known/pki-validation/[A-F0-9]{32}\.txt(?:\ Comodo\ DCV)?$
 RewriteRule software/(.*)/(.*)/downloads/(.*) https://download.open-mpi.org/release/$1/$2/$3 [L,R=301]
 
 </IfModule>


### PR DESCRIPTION
These entries were placed in our live site's .htaccess file by our
hosting provider.  We may not need them any more, but I'm a bit
nervous about removing them.  So we might as well commit them (since
they've been live on the site for forever; we might as well put them
in git so that we don't accidentally overwrite them on the live
site).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>