### PR TITLE
Update a link with correct spelling

### DIFF
--- a/about/members/index.php
+++ b/about/members/index.php
@@ -15,7 +15,7 @@ include_once("$topdir/includes/header.inc");
   of the project, participate in release processes, etc.  "Partners"
   provide services to the Open MPI project.  See the full definitions
   of these three levels of membership
-  <a href="https://github.com/open-mpi/ompi/wiki/Admistrative-rules">here</a>.</p>
+  <a href="https://github.com/open-mpi/ompi/wiki/Administrative-rules">here</a>.</p>
 
   <p>Open MPI contributors who have submitted signed 3rd Party
   Contribution Agreements and members are listed below in alphabetical

--- a/community/contribute/index.php
+++ b/community/contribute/index.php
@@ -85,7 +85,7 @@ recent development version of the code than the last stable release
 href="https://github.com/open-mpi/ompi/">Open MPI project on
 Github</a>.  All commits <em>must</em> contain a "Signed-off-by" token
 in the commit message.  This constitutes your agreement with <a
-href="https://github.com/open-mpi/ompi/wiki/Admistrative-rules#contributors-declaration">the
+href="https://github.com/open-mpi/ompi/wiki/Administrative-rules#contributors-declaration">the
 Open MPI Contributor's Declaration</a>.  Check out the overall <a
 href="https://github.com/open-mpi/ompi/blob/master/CONTRIBUTING.md">code
 contribution guidelines</a>.</li>

--- a/faq/contributing.inc
+++ b/faq/contributing.inc
@@ -96,7 +96,7 @@ intend it to remain that way.
 
 We enforce this policy by requiring all git commits to include a
 \"Signed-off-by\" token in the commit message, indicating your
-agreement to the <a href=\"https://github.com/open-mpi/ompi/wiki/Admistrative-rules#contributors-declaration\">Open
+agreement to the <a href=\"https://github.com/open-mpi/ompi/wiki/Administrative-rules#contributors-declaration\">Open
 MPI Contributor's Declaration</a>.";
 
 /////////////////////////////////////////////////////////////////////////
@@ -111,7 +111,7 @@ project *used* to require a signed Open MPI Third Party Contribution
 Agreement before we could accept code contributions.
 
 However, we have changed our policy and now only require agreement
-with the <a href=\"https://github.com/open-mpi/ompi/wiki/Admistrative-rules#contributors-declaration\">Open
+with the <a href=\"https://github.com/open-mpi/ompi/wiki/Administrative-rules#contributors-declaration\">Open
 MPI Contributor's Declaration</a>.
 
 See <a href=\"#contribute-code\">this FAQ entry for more details</a>.


### PR DESCRIPTION
As pointed out by @apjanke in issue open-mpi/ompi#6186,
we are hauling along a misspelling from SVN days.

With the corrected title in the Administrative rules wiki,
we need to update some links in the OMPI WWW repo.

The older svn links don't need to be updated since that wiki
now just points you back to the GitHUB OMPI wikis.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>