### PR TITLE
Use default auth for S3 access on most hosts

### DIFF
--- a/includes/downloads.inc
+++ b/includes/downloads.inc
@@ -15,10 +15,8 @@ use Aws\Exception\AwsException;
 if (strpos(gethostname(), 'hostgator.com') !== false) {
     $provider = CredentialProvider::ini("default", "/home2/ompiteam/.aws/credentials");
     $provider = CredentialProvider::memoize($provider);
-} elseif ($_SERVER['SERVER_NAME'] == 'aws.open-mpi.org') {
-    $provider = CredentialProvider::defaultProvider();
 } else {
-    $provider = false;
+    $provider = CredentialProvider::defaultProvider();
 }
 
 function prettyprint_filesize($size) {


### PR DESCRIPTION
For reasons that escape me, I disabled authenticating against our
S3 bucket for hosts that weren't aws.open-mpi.org or hostgator.
The creds have to come from somewhere else either way, so I was
just making it harder to do things like move www.open-mpi.org
from HostGator to AWS.

Now, we will always use the default auth provider (which will
use instance roles, environment variables, .aws/credentials/, etc.)
everywhere but HostGator, which needs the special config to
get the creds file correctly.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>