### PR TITLE
hwloc: point to ci.inria.fr/hwloc for nightly snapshots

### DIFF
--- a/software/hwloc/nightly/index.php
+++ b/software/hwloc/nightly/index.php
@@ -9,48 +9,36 @@ The following versions are available as nightly snapshots:
 
 <ul>
 
-<li> <strong>New stable release series</strong>
-
-<p><a href="v2.0/"><strong>v2.0 series</strong></a> (new stable
-release series): These snapshots are from the 2.0 branch and reflect
-the latest progression in the 2.0.x series.  The emphasis of this tree
-is on bug fixes and stability.
-<strong>This is the recommended series for all users to download and use.</strong></p>
-
+<li> <strong>v2.1 branch &mdash; New stable release series:</strong> <strong>This is the recommended series for all users to download and use.</strong>
+<p>
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v2.1/lastSuccessfulBuild/">Latest snapshot</a>
+ &mdash;
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v2.1/">All snapshots</a>
+</p>
 </li>
 
-<li> <strong>Ultra-stable release series</strong>
-
-<p><a href="v1.11/"><strong>v1.11 series</strong></a> (ultra-stable
-release series): These snapshots are from the 1.11 branch and reflect
-the latest progression in the 1.11.x series.  The emphasis of this tree
-is on bug fixes and stability.
-<strong>This is the recommended series for users that have a good reason not to switch to v2.0 yet.</strong></p>
-
+<li> <strong>v2.0 branch &mdash; Former stable release series:</strong>
+<p>
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v2.0/lastSuccessfulBuild/">Latest snapshot</a>
+ &mdash;
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v2.0/">All snapshots</a>
+</p>
 </li>
 
-<li> <strong>Previous stable release series (v1.10, etc) are considered too old and obsolete.</strong>
-<p></p>
+<li> <strong>v1.11 branch &mdash; Former ultra-stable release series:</strong> This was the recommended series for users that had a good reason not to switch to v2.x yet.
+<p>
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v1.11/lastSuccessfulBuild/">Latest snapshot</a>
+ &mdash;
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/v1.11/">All snapshots</a>
+</p>
 </li>
 
-<!--
-<li> <strong>Previous stable release series</strong>
-
-<p><a href="v1.10/"><strong>v1.10 series</strong></a> (previous stable
-release series): These snapshots are from the 1.10 branch and reflect
-the latest progression in the 1.10.x series.  The emphasis of this tree
-is on bug fixes and stability.</p>
-
-</li>
--->
-
-<li> <strong>Current development</strong>
-
-<p><a href="master/"><strong>Master</strong></a> (development head):
-These snapshots are from the git master branch and reflect the current
-head of development.  The usual disclaimers about the state of
-development code apply.</p>
-
+<li> <strong>Master branch &mdash; Current development head:</strong> The usual disclaimers about the state of development code apply.
+<p>
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/master/lastSuccessfulBuild/">Latest snapshot</a>
+ &mdash;
+ <a href="https://ci.inria.fr/hwloc/job/extended/job/master/">All snapshots</a>
+</p>
 </li>
 
 </ul>


### PR DESCRIPTION
Those snapshots are built by Jenkins during nightly extended tests.
They include Windows zipballs, PDF/HTML documentation, etc.

Former nightly pages for v1.11, v2.0 and master still exist
and are updated, we'll remove them in a couple weeks/months
unless something bad happens.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>