### PR TITLE
Update release box URLs

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,10 +91,10 @@ news("SC'19 State of the Union BOF",
      "https://www.open-mpi.org/sc19/");
 news("Open MPI v3.1.5 released",
      "Bug fix release",
-     "https://www.open-mpi.org/software/ompi/v3.1/");
+     "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00126.html");
 news("Open MPI v3.0.5 released",
      "Bug fix release",
-     "https://www.open-mpi.org/software/ompi/v3.0/");
+     "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00126.html");
 news("Open MPI v4.0.2 released",
      "Bug fix release",
      "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00124.html");


### PR DESCRIPTION
Due to the fast release of 3.0.5 and 3.1.5 in time for the SC'19
BOF, an announce email wasn't sent at time of release.  Now that
we have cleaned up from that delay, include the announce email
link in the front page boxes.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>