### PR TITLE
add volatile qualifier to sleep flag for gdb attach to process

### DIFF
--- a/faq/debugging.inc
+++ b/faq/debugging.inc
@@ -188,7 +188,7 @@ attach:
 
 <geshi c>
 {
-    int i = 0;
+    volatile int i = 0;
     char hostname[256];
     gethostname(hostname, sizeof(hostname));
     printf(\"PID %d on %s ready for attach\\n\", getpid(), hostname);


### PR DESCRIPTION
If the sleep flag variable 'i' is not declared as volatile, most compilers will
not allocate a memory address, meaning that it cannot be set in gdb using
'set var i = 7' as suggested.