### PR TITLE
Debugging FAQ: add mention of 'tmpi' and don't scare off people of trying the 'xterm' method

### DIFF
--- a/faq/debugging.inc
+++ b/faq/debugging.inc
@@ -223,8 +223,8 @@ or whatever process is misbehaving).
 
 </li>
 
-<li> <strong>Use <code>mpirun</code> to launch <code>xterm</code>s
-(or equivalent) with serial debuggers.</strong>
+<li> <strong>Use <code>mpirun</code> to launch separate instances
+of serial debuggers.</strong>
 
 This technique launches a separate window for each MPI process in
 MPI_COMM_WORLD, each one running a serial debugger (such as [gdb])
@@ -239,8 +239,13 @@ shell$ mpirun -np 4 xterm -e gdb my_mpi_application
 </geshi>
 
 If running on a personal computer, this will probably work.
-Unfortunately, it likely _won't_ work on an computing cluster.
-Several factors must be considered:
+You can also use " . aurchin_click("https://github.com/Azrael3000/tmpi") .
+"<code>tmpi</code></a> to launch the debuggers in separate [tmux]
+panes instead of separate [xterm] windows, which has the advantage of
+synchronizing keyboard input between all debugger instances.
+
+Unfortunately, the [tmpi] or [xterm] approaches likely _won't_ work
+on an computing cluster. Several factors must be considered:
 
 <ol>
 

--- a/faq/debugging.inc
+++ b/faq/debugging.inc
@@ -223,8 +223,8 @@ or whatever process is misbehaving).
 
 </li>
 
-<li> *Use [mpirun] to launch <code>xterm</code>s (or equivalent) with
-serial debuggers.*
+<li> <strong>Use <code>mpirun</code> to launch <code>xterm</code>s
+(or equivalent) with serial debuggers.</strong>
 
 This technique launches a separate window for each MPI process in
 MPI_COMM_WORLD, each one running a serial debugger (such as [gdb])

--- a/faq/debugging.inc
+++ b/faq/debugging.inc
@@ -238,8 +238,9 @@ assume that the following would immediately work:
 shell$ mpirun -np 4 xterm -e gdb my_mpi_application
 </geshi>
 
-Unfortunately, it likely _won't_ work.  Several factors must be
-considered:
+If running on a personal computer, this will probably work.
+Unfortunately, it likely _won't_ work on an computing cluster.
+Several factors must be considered:
 
 <ol>
 


### PR DESCRIPTION
- The `mpirun -np <n> xterm -e gdb <app>` method usually works well
on personal computers. Mention this early on, so that potential readers
wanting to debug on their own machine are not discouraged of trying it
by the long section below.

- [`tmpi`](https://github.com/Azrael3000/tmpi) is a small script that uses the terminal multiplexer
`tmux` to launch separate instances of an OpenMPI program. It can be used to debug MPI applications by launching separate debugger
processes for each rank, and has the advantage of synchronizing
keyboard input to all debugger instances. Add a mention of this nice script in the debugging section of the
FAQ.

- Also, a small markup fix