### PR TITLE
Don't use `aurchin_click`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,13 @@ Use the normal "GitHub flow" to make a pull request:
 
 We're not *as* picky about code on our web site as we are with code in the main Open MPI code repository, but having good, easy-to-read and easy-to-review commits is definitely helpful.
 
-Testing your commits before making the pull request is strongly suggested.  You should be able to test most functionality on the web site with any modern PHP-enabled web server.
+Testing your commits before making the pull request is strongly suggested.  You should be able to test most functionality on the web site with any modern PHP-enabled web server. This should be as easy as:
+```bash
+cd /path/to/ompi-www
+php -S localhost:8000
+# point your browser to http://localhost:8000/
+# check your changes
+```
 
 Before submitting, please read the [Contributing to the Open MPI Project FAQ](https://www.open-mpi.org/faq/?category=contributing) web page, and the [SubmittingPullRequests](https://github.com/open-mpi/ompi/wiki/SubmittingPullRequests) wiki page.  In particular, note that all Git commits contributed to Open MPI require a "Signed-off-by" line.
 

--- a/faq/debugging.inc
+++ b/faq/debugging.inc
@@ -239,8 +239,8 @@ shell$ mpirun -np 4 xterm -e gdb my_mpi_application
 </geshi>
 
 If running on a personal computer, this will probably work.
-You can also use " . aurchin_click("https://github.com/Azrael3000/tmpi") .
-"<code>tmpi</code></a> to launch the debuggers in separate [tmux]
+You can also use <a href=\"https://github.com/Azrael3000/tmpi\">
+<code>tmpi</code></a> to launch the debuggers in separate [tmux]
 panes instead of separate [xterm] windows, which has the advantage of
 synchronizing keyboard input between all debugger instances.
 


### PR DESCRIPTION
When I did #316 I read the [Wiki entry](https://github.com/open-mpi/ompi/wiki/OMPIFAQEntries) linked in the [CONTRIBUTING](https://github.com/open-mpi/ompi-www/blob/master/.github/CONTRIBUTING.md) document and did not check my changes (I did not know it was as easy as `php -S localhost:8000`), and it turns out the wiki entry is not up to date, so the Debugging FAQ does not work at the moment because of the call to `aurchin_click`.

- Add an example of local testing in CONTRIBUTING ([should work with PHP >=5.4](https://www.php.net/manual/en/features.commandline.webserver.php))
- Remove the call to `aurchin_click` that makes the page fail.

@jsquyres 