### PR TITLE
robots.txt: disallow indexing user dirs

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,6 @@
 User-agent: *
 Disallow: /community/lists/
+Disallow: /~jsquyres
+Disallow: /~bgoglin
+Disallow: /~bbarrett
+Disallow: /~*


### PR DESCRIPTION
As of Jan 2021, some `www.open-mpi.org/~jsquyres/*` URLs show up in
Google searches.  This is not desirable, because they get confused
with the real web site.  So disallow all crawlers from indexing any
`~username` URLs.  It's not 100% clear if `~*` wildcard matching works
in a robots.txt, so throw in a handful of actual usernames that we
want to block, just to be sure.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>