### PR TITLE
Update to point to github README.md

### DIFF
--- a/includes/header.inc
+++ b/includes/header.inc
@@ -232,8 +232,7 @@ printsublink("$topurl/software/", "Download");
 printsublink("$topurl/doc/", "Documentation");
 printsublink("$topurl/source/", "Source Code Access");
 printsublink("$topurl/community/help/bugs.php", "Bug Tracking");
-// MTT is not mirrored
-printsublink("http://mtt.open-mpi.org/", "Regression Testing");
+printsublink("https://mtt.open-mpi.org/", "Regression Testing");
 printsublink("https://github.com/open-mpi/ompi/blob/master/README.md#open-mpi-version-numbers-and-binary-compatibility", "Version Information");
 
 // Sub-Projects

--- a/includes/header.inc
+++ b/includes/header.inc
@@ -234,7 +234,7 @@ printsublink("$topurl/source/", "Source Code Access");
 printsublink("$topurl/community/help/bugs.php", "Bug Tracking");
 // MTT is not mirrored
 printsublink("http://mtt.open-mpi.org/", "Regression Testing");
-printsublink("$topurl/software/ompi/versions/", "Version Information");
+printsublink("https://github.com/open-mpi/ompi/blob/master/README.md#open-mpi-version-numbers-and-binary-compatibility", "Version Information");
 
 // Sub-Projects
 printbutton("Sub-Projects");

--- a/software/ompi/versions/index.php
+++ b/software/ompi/versions/index.php
@@ -1,24 +1,2 @@
 <?php
-  $topdir = "../../..";
-  $title = "Open MPI: Version Number Methodology";
-  include_once("$topdir/software/ompi/versions/nav.inc");
-  include_once("$topdir/includes/header.inc");
-  include_once("$topdir/includes/curl_get.inc");
-?>
-
-The following text is taken directly from the <?php
-print("<a href=\"https://github.com/open-mpi/ompi/blob/master/README\">"); ?>
-Open MPI README file</a> in the development branch.
-
-<?php
-$str = do_curl_get("https://raw.githubusercontent.com/open-mpi/ompi/master/README");
-
-# Extract just the sections we want from the README.
-
-$str = preg_replace("/.+(\nOpen MPI Version Numbers.+)/si", "$1", $str);
-$str = preg_replace("/(.+)Checking Your Open MPI Installation.+/si", "$1", $str);
-$str = preg_replace("/={5,}/", "", $str);
-$str = preg_replace("/\n\n\n/s", "\n\n", $str);
-print("<p><hr>\n<pre>\n$str\n</pre><p><hr>\n\n");
-
-  include_once("$topdir/includes/footer.inc");
+  header("Location: https://github.com/open-mpi/ompi/blob/master/README.md#open-mpi-version-numbers-and-binary-compatibility");


### PR DESCRIPTION
We used to download README from github and slurp out the section that
we wanted to show.  With the conversion to README.md, this is a little
more difficult.  So instead, just redirect out to the proper
subsection in README.md at github.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>