### PR TITLE
Fix latest_snapshot.txt rendering

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,7 +36,7 @@ Deny from 180.211.180.14
 # PHP script that generates the right answer, so turn
 # on PHP processing for those files.
 <Files "latest_snapshot.txt">
-     AddHandler application/x-httpd-php56 .txt
+     AddHandler application/x-httpd-php .txt
 </Files>
 
 ## Comment these rules in if you want to have nice URLs using


### PR DESCRIPTION
The specification of php56 instead of generic php was a holdover
from the HostGator timeframe.  When we recently removed php56,
that broke rendering of latest_snapshot.txt.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>