### PR TITLE
v5.0/srpm.php: Fix broken README link.

### DIFF
--- a/software/ompi/v5.0/srpm.php
+++ b/software/ompi/v5.0/srpm.php
@@ -13,8 +13,8 @@
   $rawbase_url = "https://raw.githubusercontent.com/open-mpi/ompi";
   $linux_dir = "$release_branch/contrib/dist/linux";
 
-  $readme = "$base_url/$linux_dir/README";
-  $raw_readme = "$rawbase_url/$linux_dir/README";
+  $readme = "$base_url/$linux_dir/README.md";
+  $raw_readme = "$rawbase_url/$linux_dir/README.md";
   $build_script = "$base_url/$linux_dir/buildrpm.sh";
   $specfile = "$base_url/$linux_dir/openmpi.spec";
 ?>


### PR DESCRIPTION
In master/v5 ompi, this changed from README -> README.md.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>