### PR TITLE
Fix verion typo in 4.1 timeline.

### DIFF
--- a/software/ompi/v4.1/timeline-graph.php
+++ b/software/ompi/v4.1/timeline-graph.php
@@ -34,8 +34,8 @@ milestone("v4.1.0", "2020-12-18", $data, $vpos);
 #milestone("v4.1.1rc3", "2021-04-20", $data, $vpos);
 #milestone("v4.1.1rc4", "2021-04-22", $data, $vpos);
 milestone("v4.1.1", "2021-04-24", $data, $vpos);
-milestone("v4.1.1rc1", "2021-09-24", $data, $vpos);
-milestone("v4.1.1rc2", "2021-10-27", $data, $vpos);
+milestone("v4.1.2rc1", "2021-09-24", $data, $vpos);
+milestone("v4.1.2rc2", "2021-10-27", $data, $vpos);
 
 // Party on
 $graph->CreateSimple($data);


### PR DESCRIPTION
I must have cut-n-pasted the entry for 4.1.2rc1 from 4.1.1 and
not updated it, then copied it again.  Thanks to Kawashima
Takahiro for pointing out the mistake.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>