### PR TITLE
Really release Open MPI 4.1.3

### DIFF
--- a/index.php
+++ b/index.php
@@ -86,21 +86,15 @@ information</a></h3>
 <td valign=top>
 
 <?php
+news("Open MPI v4.1.3 released",
+     "Bug fix release",
+     "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00147.html");
 news("Open MPI v4.1.2 released",
      "Bug fix release",
      "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00145.html");
 news("Open MPI v4.0.7 released",
      "Bug fix release",
      "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00144.html");
-news("Open MPI v4.0.6 released",
-     "Bug fix release",
-     "https://www.mail-archive.com/announce@lists.open-mpi.org//msg00142.html");
-news("Open MPI v4.1.1 released",
-     "Bug fix release",
-     "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00141.html");
-news("Open MPI v4.0.5 released",
-     "Bug fix release",
-     "https://www.mail-archive.com/announce@lists.open-mpi.org/msg00135.html");
 news("hwloc 2.7.1",
      "Stable release",
      "https://www.mail-archive.com/hwloc-announce@lists.open-mpi.org/msg00149.html");

--- a/software/ompi/v4.1/timeline-graph.php
+++ b/software/ompi/v4.1/timeline-graph.php
@@ -38,8 +38,9 @@ milestone("v4.1.1", "2021-04-24", $data, $vpos);
 #milestone("v4.1.2rc2", "2021-10-27", $data, $vpos);
 #milestone("v4.1.2rc3", "2021-11-17", $data, $vpos);
 milestone("v4.1.2", "2021-11-24", $data, $vpos);
-milestone("v4.1.3rc1", "2022-03-17", $data, $vpos);
-milestone("v4.1.3rc2", "2022-03-29", $data, $vpos);
+#milestone("v4.1.3rc1", "2022-03-17", $data, $vpos);
+#milestone("v4.1.3rc2", "2022-03-29", $data, $vpos);
+milestone("v4.1.3", "2022-03-31", $data, $vpos);
 
 // Party on
 $graph->CreateSimple($data);

--- a/software/ompi/v4.1/version.inc
+++ b/software/ompi/v4.1/version.inc
@@ -11,11 +11,11 @@ $download_prefix="https://download.open-mpi.org/release/open-mpi/v" . $release_s
 $s3_prefix = "release/open-mpi/v" . $release_series . "/";
 
 /* releases must be ordered newest to oldest */
-$releases = array("4.1.2", "4.1.1", "4.1.0");
+$releases = array("4.1.3", "4.1.2", "4.1.1", "4.1.0");
 /* prereleases must be ordered newest to oldest.  All prereleases
    will be shown, so make an empty array when the official release
    is added to releases above */
-$prereleases = array("4.1.3rc2", "4.1.3rc1");
+$prereleases = array();
 
 /* set to true if we should add a cygwin note */
 $cygwin_note = 0;


### PR DESCRIPTION
I forgot to add the three version files to actually release in the
previous commit.  Sigh.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>