### PR TITLE
OMPI v5.0.0rc8 updates.

### DIFF
--- a/software/ompi/v5.0/timeline-graph.php
+++ b/software/ompi/v5.0/timeline-graph.php
@@ -34,6 +34,8 @@ milestone("v5.0.0rc3", "2022-03-08", $data, $vpos);
 milestone("v5.0.0rc4", "2022-03-31", $data, $vpos);
 milestone("v5.0.0rc5", "2022-04-07", $data, $vpos);
 milestone("v5.0.0rc6", "2022-04-15", $data, $vpos);
+milestone("v5.0.0rc7", "2022-05-13", $data, $vpos);
+milestone("v5.0.0rc8", "2022-09-29", $data, $vpos);
 
 // Party on
 $graph->CreateSimple($data);

--- a/software/ompi/v5.0/version.inc
+++ b/software/ompi/v5.0/version.inc
@@ -15,7 +15,7 @@ $releases = array();
 /* prereleases must be ordered newest to oldest.  All prereleases
    will be shown, so make an empty array when the official release
    is added to releases above */
-$prereleases = array("5.0.0rc7", "5.0.0rc6", "5.0.0rc5", "5.0.0rc4", "5.0.0rc3", "5.0.0rc2", "5.0.0rc1");
+$prereleases = array("5.0.0rc8", "5.0.0rc7", "5.0.0rc6", "5.0.0rc5", "5.0.0rc4", "5.0.0rc3", "5.0.0rc2", "5.0.0rc1");
 
 /* set to true if we should add a cygwin note */
 $cygwin_note = 0;


### PR DESCRIPTION
Also include a missing rc7 update to the timeline. I forgot to `git add` that file last go around.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>