### PR TITLE
Add GitHub Actions for git commit checks

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,28 @@
+name: GitHub Action CI
+
+# We're using pull_request_target here instead of just pull_request so that the
+# action runs in the context of the base of the pull request, rather than in the
+# context of the merge commit. For more detail about the differences, see:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+on:
+    pull_request_target:
+        # We don't need this to be run on all types of PR behavior
+        # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+        types:
+          - opened
+          - synchronize
+          - edited
+
+permissions: {} # none
+
+jobs:
+  check:
+    permissions:
+      pull-requests: write
+    name: Check Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Commit Checker
+        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        with:
+          token: "${{ secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
Move the git commit checkers to GitHub Actions, following the trend of the other Open MPI repositories.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>