### PR TITLE
Fix hyperlink to v5.0.x NEWS file

### DIFF
--- a/software/ompi/v5.0/index.php
+++ b/software/ompi/v5.0/index.php
@@ -18,10 +18,10 @@ include_once("$topdir/includes/subscribe-announce.inc");
 
 <p><hr>
 
-<P><?php $dir = "https://github.com/open-mpi/ompi/raw/$release_branch/NEWS";
+<P><?php $dir = "https://docs.open-mpi.org/en/v5.0.x/release-notes/index.html";
       print("<a href=\"$dir\">"); ?>This
-file</a> contains a list of changes between the releases in the Open
-MPI in the v<?php print("$release_series"); ?> series.</p>
+file</a> contains the release notes for the Open
+MPI v<?php print("$release_series"); ?> series.</p>
 
 <p>See the <a href="<?php print($topdir);
 ?>/software/ompi/versions/timeline.php">version timeline</a> for


### PR DESCRIPTION
We don't have a NEWS file any more.  Instead, link to the v.5.0.x on docs.open-mpi.org.

Thanks to @BenWibking for the heads up that the link was broken.

Refs: https://github.com/open-mpi/ompi/issues/11572