### PR TITLE
Update mailing list links for Google Groups

### DIFF
--- a/community/lists/functions.inc
+++ b/community/lists/functions.inc
@@ -1,5 +1,5 @@
 <?php
-function print_link($name, $dir) {
+function print_link($name, $dir, $emit_ggroups=True) {
     global $topdir;
     global $is_mirror;
 
@@ -8,12 +8,16 @@ function print_link($name, $dir) {
      [ ");
 
     if (is_dir($dir) || is_link($dir)) {
-        print("<a href=\"https://www.mail-archive.com/$dir@lists.open-mpi.org//\">Archives</a> | \n");
+        print("<a href=\"https://www.mail-archive.com/$dir@lists.open-mpi.org//\">Complete archives</a>");
+        if ($emit_ggroups) {
+            print(" | \n");
+        }
     }
 
-    // Mailman is not mirrored, of course -- must link to the original page
-    print("<a href=\"http://lists.open-mpi.org/mailman/listinfo/$dir\">Subscribe, unsubscribe, or change options</a> ]
-");
+    if ($emit_ggroups) {
+        print("<a href=\"https://groups.google.com/a/lists.open-mpi.org/g/$dir\">Subscribe, unsubscribe, or change options (Google Groups)</a>");
+    }
+    print(" ]\n");
 }
 
 function red($msg) {
@@ -22,10 +26,6 @@ function red($msg) {
 
 function print_list($name) {
     printf("<P><CENTER>\n");
-    red("YOU MUST BE SUBSCRIBED IN ORDER TO POST TO THE LIST");
-    printf("<br /\n>");
-    print_mailto("lists.open-mpi.org", $name, "$name at lists dot open dash mpi dot org");
-    printf("<br /\n>");
-    red("YOU MUST BE SUBSCRIBED IN ORDER TO POST TO THE LIST");
+    print_mailto("lists.open-mpi.org", $name, "$name@lists.open-mpi.org");
     printf("</center></p>\n\n");
 }

--- a/community/lists/hwloc.php
+++ b/community/lists/hwloc.php
@@ -9,23 +9,14 @@ include_once("$topdir/includes/mailto.inc");
 include_once("$topdir/includes/header.inc");
 ?>
 
-<p><center><?php red("YOU MUST BE SUBSCRIBED IN ORDER TO POST!");
-?></center></p>
-
-<p> Due to the ever-present problem of spam, we cannot accept posts
-from non-subscribers.  If you are not subscribed <?php red("with the
-address that you post from"); ?>, you posts will be automatically
-discarded.</p>
-
 <p><center><hr width=50%></center>
 
-<h2 align=center><font color=red>NOTE:</font> New subscriptions to
-the mailing lists curently broken.</h2>
+<p> Hwloc's mailing lists are hosted at Google Groups, which
+contains archived conversations going back to January, 2025.</p>
 
-<h2 align=center>Please <a
-href="https://github.com/open-mpi/hwloc/issues/new/choose">create a
-GitHub issue with any questions</a> until we can get the mailing lists
-fixed.</h2>
+<p> However, Hwloc's <em>complete</em> mail archives go back much
+further than that and are available at <a
+href="https://mail-archive.com/">https://mail-archive.com/</a>.</p>
 
 <p><center><hr width=50%></center>
 
@@ -54,24 +45,12 @@ suspected bug reports, etc. to the list at the following address:</p>
 
 <?php print_list("hwloc-users"); ?>
 
-<?php print_link("hwloc developers list", "hwloc-devel"); ?>
+<?php print_link("hwloc developers list", "hwloc-devel", $emit_ggroups=False); ?>
 
-<P>This list is used for general questions and discussion of hwloc.
-Please see the "<a href="<?php printf("$topdir/community/help/");
-?>">Getting Help</a>" page for details on submitting requests for
-help.  <?php red("Subscribers"); ?> can post questions, comments,
-suspected bug reports, etc. to the list at the following address:</p>
-
-<?php print_list("hwloc-devel"); ?>
-
-<?php print_link("Git commit list (<font color=red>USERS
-CANNOT POST TO THIS LIST</font>)", "hwloc-commits"); ?>
-
-<p>A mail is sent to this list for every git push to Github in the
-hwloc code base.  The mail includes a list of files that were changed,
-the developer's commit message, and a diff of the changes.  <strong>Only the
-automated Github web hook post to this list;</strong> all other posts
-are automatically discarded.
+<P>This list used to be for developers who were working with the
+internals of hwloc itself.  Due to low volume, this list is no longer
+available -- it has been folder into the hwloc user's list.  The old
+archives are still available, however.</p>
 
 </UL>
 

--- a/community/lists/mtt.php
+++ b/community/lists/mtt.php
@@ -11,23 +11,14 @@ include_once("$topdir/includes/mailto.inc");
 include_once("$topdir/includes/header.inc");
 ?>
 
-<p><center><?php red("YOU MUST BE SUBSCRIBED IN ORDER TO POST!");
-?></center></p>
-
-<p> Due to the ever-present problem of spam, we cannot accept posts
-from non-subscribers.  If you are not subscribed <?php red("with the
-address that you post from"); ?>, you posts will be automatically
-discarded.</p>
-
 <p><center><hr width=50%></center>
 
-<h2 align=center><font color=red>NOTE:</font> New subscriptions to
-the mailing lists curently broken.</h2>
+<p> MTT's mailing lists are hosted at Google Groups, which
+contains archived conversations going back to January, 2025.</p>
 
-<h2 align=center>Please <a
-href="https://github.com/open-mpi/mtt/issues/new/choose">create a
-GitHub issue with any questions</a> until we can get the mailing lists
-fixed.</h2>
+<p> However, MTT's <em>complete</em> mail archives go back much
+further than that and are available at <a
+href="https://mail-archive.com/">https://mail-archive.com/</a>.</p>
 
 <p><center><hr width=50%></center>
 
@@ -36,15 +27,6 @@ print($topdir); ?>/projects/mtt/">MTT</a> community:</p>
 
 <P>
 <UL>
-
-<?php print_link("MTT announcement list (<font color=red>USERS
-CANNOT POST TO THIS LIST</font>)", "mtt-announce"); ?>
-
-<P> This is a low-volume list that is used to announce new version of
-MTT, important updates, etc.  The list is only for announcements, so
-<strong>only the MTT development team can post to the list.</strong>
-Posts from outside the MTT development team will be automatically
-discarded.</p>
 
 <?php print_link("MTT user list", "mtt-users"); ?>
 
@@ -56,14 +38,12 @@ suspected bug reports, etc. to the list at the following address:</p>
 
 <?php print_list("mtt-devel"); ?>
 
-<?php print_link("MTT developers list", "mtt-devel"); ?>
+<?php print_link("MTT developers list", "mtt-devel", $emit_ggroups=False); ?>
 
-<P>This list is used for developers who are working with the internals
-of MTT itself.  <?php red("Subscribers"); ?> are welcome to post
-any topics dealing with the internal code of MTT are welcome on
-this list: questions, comments, bug reports, etc.</p>
-
-<?php print_list("mtt-devel"); ?>
+<P>This list used to be for developers who were working with the
+internals of MTT itself.  Due to very low volume, this list is no
+longer available -- it has been folder into the MTT user's list.  The
+old archives are still available, however.</p>
 </UL>
 
 <?php

--- a/community/lists/ompi.php
+++ b/community/lists/ompi.php
@@ -9,30 +9,18 @@ include_once("$topdir/includes/mailto.inc");
 include_once("$topdir/includes/header.inc");
 ?>
 
-<h2> Please do not send conference Call For Papers/Posters/Abstracts/etc. (and related) notices to our mailing lists.</h2>
-
-<p><center><?php red("YOU MUST BE SUBSCRIBED IN ORDER TO POST!");
-?></center></p>
-
-<p> Due to the ever-present problem of spam, we cannot accept posts
-from non-subscribers.  If you are not subscribed <?php red("with the
-address that you post from"); ?>, you posts will be automatically
-discarded.</p>
-
-<p>Please note that our mailing lists have a <strong>150 KB</strong>
-message size limit.  If you need to send an attachment that makes your
-overall message be over that size, please post it elsewhere on the
-internet and then just send a link to it across our lists.</p>
+<h2> Please do not send conference Call For
+Papers/Posters/Abstracts/etc. (and related) notices to our mailing
+lists.</h2>
 
 <p><center><hr width=50%></center>
 
-<h2 align=center><font color=red>NOTE:</font> New subscriptions to
-the mailing lists curently broken.</h2>
+<p> Open MPI's mailing lists are hosted at Google Groups, which
+contains archived conversations going back to January, 2025.</p>
 
-<h2 align=center>Please <a
-href="https://github.com/open-mpi/ompi/issues/new/choose">create a
-GitHub issue with any questions</a> until we can get the mailing lists
-fixed.</h2>
+<p> However, Open MPI's <em>complete</em> mail archives go back much
+further than that and are available at <a
+href="https://mail-archive.com/">https://mail-archive.com/</a>.</p>
 
 <p><center><hr width=50%></center>
 
@@ -93,17 +81,6 @@ topics dealing with platform support, packaging details, dependencies,
 etc.</p>
 
 <?php print_list("ompi-packagers"); ?>
-
-<!--------------------------------------------------------------------->
-
-<?php print_link("Git commit list (<font
-color=red>USERS CANNOT POST TO THIS LIST</font>)", "ompi-commits"); ?>
-
-<p>A mail is sent to this list for every Git push to Github commit in
-the Open MPI code base.  The mail includes a list of files that were
-changed, the developer's commit message, and a diff of the changes.
-<strong>Only the automated git-email-bot can post to this
-list;</strong> all other posts are automatically discarded.
 
 </UL>
 


### PR DESCRIPTION
In January of 2025, we migrated all the mailing lists away from GNU Mailman to Google Groups.  We also consolidated and removed a few lists.

Update the mailing list pages to reflect the most current / correct information about the Open MPI, hwloc, and MTT mailing lists.