### PR TITLE
Prefer docs.open-mpi.org for current documentation

### DIFF
--- a/community/help/index.php
+++ b/community/help/index.php
@@ -1,7 +1,11 @@
 <?php
   // This page has been obsoleted by the "Getting help" page on
-  // docs.open-mpi.org.  We intentionally send people to the "main"
-  // release's "Getting help" page (vs. any specific release).
+  // docs.open-mpi.org.
 
-header("Location: https://docs.open-mpi.org/en/main/getting-help.html",
+$topdir = "../..";
+include_once("$topdir/software/ompi/current/version.inc");
+
+$docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
+
+header("Location: https://docs.open-mpi.org/en/$docs_release_branch/getting-help.html",
        TRUE, 301);

--- a/includes/header.inc
+++ b/includes/header.inc
@@ -16,6 +16,10 @@ if (!isset($logo_url)) {
 if (!isset($project)) {
     $project = "Open MPI";
 }
+include_once("$topdir/software/ompi/current/version.inc");
+$ompi_docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
+$is_faq_page = (isset($_SERVER["REQUEST_URI"]) &&
+                preg_match("/^\/faq(\/|\?|$)/", $_SERVER["REQUEST_URI"]) == 1);
 
 // For debugging
 $table_border = 0;
@@ -86,6 +90,55 @@ function printtoplink($link, $text, $class) {
 function printbutton($text) {
   global $topdir;
   print("<tr><td class=\"buttonbox\">&nbsp;$text</td></tr>\n\n");
+}
+
+function print_old_doc_notice() {
+    global $release_branch;
+    global $ver_current_dir;
+
+    $uri = isset($_SERVER["REQUEST_URI"]) ? $_SERVER["REQUEST_URI"] : "";
+
+    $pattern = "/\/doc\/(current|v[1-4](\.[0-9]+)?)\/man([137])\/" .
+               "([^\/?#]+)\.\\3\.php/";
+    if (preg_match($pattern, $uri, $matches) != 1) {
+        return;
+    }
+
+    $section = $matches[3];
+    $manpage = $matches[4];
+    $docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
+    $docs_release_label = $ver_current_dir;
+    $docs_man_url = "https://docs.open-mpi.org/en/$docs_release_branch/man-openmpi";
+    $docs_url = "$docs_man_url/";
+    $link_text = "the current Open MPI manual pages";
+    $wrapper_compilers = array("mpicc", "mpic++", "mpicxx", "mpif77",
+                               "mpif90", "mpifort", "opalcc", "opalc++",
+                               "oshcc", "oshc++", "oshcxx", "oshfort",
+                               "shmemcc", "shmemc++", "shmemcxx",
+                               "shmemfort");
+
+    if ($section == "3" && preg_match("/^MPI_/", $manpage) == 1) {
+        $docs_url = "$docs_man_url/man3/$manpage.3.html";
+        $link_text = "the current $manpage($section) man page";
+    } else if ($section == "1" && in_array($manpage, $wrapper_compilers, TRUE)) {
+        $docs_url = "$docs_man_url/man1/ompi-wrapper-compiler.1.html";
+        $link_text = "the current Open MPI wrapper compiler man page";
+    } else if ($section == "1" && ($manpage == "mpirun" || $manpage == "mpiexec")) {
+        $docs_url = "$docs_man_url/man1/mpirun.1.html";
+        $link_text = "the current mpirun(1) man page";
+    } else if ($section == "1" && $manpage == "ompi_info") {
+        $docs_url = "$docs_man_url/man1/ompi_info.1.html";
+        $link_text = "the current ompi_info(1) man page";
+    }
+
+    $docs_url = htmlspecialchars($docs_url, ENT_QUOTES);
+    $docs_release_label = htmlspecialchars($docs_release_label, ENT_QUOTES);
+    $link_text = htmlspecialchars($link_text, ENT_QUOTES);
+    print("<div style=\"border: 1px solid #c0c0c0; background: #f8f8f8; padding: 8px; margin: 0 0 12px 0;\">\n");
+    print("This is documentation for an older version of Open MPI. ");
+    print("For Open MPI $docs_release_label and later, see ");
+    print("<a href=\"$docs_url\">$link_text</a> on docs.open-mpi.org.\n");
+    print("</div>\n");
 }
 
 function printsublink($link, $text, $a_modifier = "") {
@@ -188,8 +241,10 @@ print("      <h1 class=\"doctitle\">$title</H1>\n");
 	<a href="<?php print("$topurl"); ?>/" class="quickbar">Home</A>
 	<span class="divider">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
 	<a href="<?php print("$topurl"); ?>/community/help/" class="quickbar"><font color=red>Support</font></A>
+<?php if ($is_faq_page) { ?>
 	<span class="divider">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
 	<a href="<?php print("$topurl"); ?>/faq/" class="quickbar">FAQ</A>
+<?php } ?>
 	<span class="divider">&nbsp;&nbsp;|&nbsp;&nbsp;</span>
 	<?php nav_search_make(); ?>
        </td>
@@ -222,7 +277,9 @@ print("      <h1 class=\"doctitle\">$title</H1>\n");
 printbutton("About");
 printsublink("$topurl/papers/", "Presentations");
 printsublink("$topurl/about/members/", "Open MPI Team");
-printsublink("$topurl/faq/", "FAQ");
+if ($is_faq_page) {
+    printsublink("$topurl/faq/", "FAQ");
+}
 printsublink("$topurl/video/", "Videos");
 printsublink("$topurl/performance/", "Performance");
 
@@ -233,7 +290,7 @@ printsublink("$topurl/doc/", "Documentation");
 printsublink("$topurl/source/", "Source Code Access");
 printsublink("https://github.com/open-mpi/ompi/issues", "Bug Tracking");
 printsublink("https://mtt.open-mpi.org/", "Regression Testing");
-printsublink("https://docs.open-mpi.org/en/main/version-numbering.html", "Version Information");
+printsublink("https://docs.open-mpi.org/en/$ompi_docs_release_branch/version-numbering.html", "Version Information");
 
 // Sub-Projects
 printbutton("Sub-Projects");
@@ -245,9 +302,8 @@ printsublink("$topurl/projects/otpo/", "Open Tool for Parameter Optimization");
 // Community
 printbutton("Community");
 printsublink("$topurl/community/lists/", "Mailing Lists");
-// Set the "Getting Help" link to be the main "Getting Help" page on
-// the on docs.open-mpi.org (vs. any specific release).
-printsublink("https://docs.open-mpi.org/en/main/getting-help.html",
+// Set the "Getting Help" link to the current release docs.
+printsublink("https://docs.open-mpi.org/en/$ompi_docs_release_branch/getting-help.html",
              "<font color=red>Getting Help/Support</font>");
 printsublink("$topurl/community/contribute/", "Contribute");
 printsublink("$topurl/community/contact.php", "Contact");
@@ -278,4 +334,5 @@ printbutton("");
 if (file_exists("$topdir/sitewide_notice.inc")) {
   include("$topdir/sitewide_notice.inc");
 }
+print_old_doc_notice();
 ?>

--- a/index.php
+++ b/index.php
@@ -76,8 +76,8 @@ of research, academic, and industry partners.  The <a
 href="about/members/">Open MPI Team</a> page has a comprehensive
 listing of all contributors and active members.</p>
 
-<h3 align=center><a href="faq/">See the FAQ page for more technical
-information</a></h3>
+<h3 align=center><a href="https://docs.open-mpi.org/">See the Open MPI
+documentation for more technical information</a></h3>
 
 <h3 align=center><a href="community/lists/">Join the mailing lists</a></h3>
 

--- a/papers/workshop-2006/prerequisites.php
+++ b/papers/workshop-2006/prerequisites.php
@@ -1,6 +1,8 @@
 <?php
 $topdir = "../..";
 $title = "Open MPI Developer's Workshop: Prerequisites";
+include_once("$topdir/software/ompi/current/version.inc");
+$ompi_docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
 include_once("$topdir/includes/mailto.inc");
 include_once("$topdir/includes/header.inc");
 ?>
@@ -313,9 +315,9 @@ build is complete and ready for testing.
 
 <P>For now, we can just use a simple Hello, World example to make sure
 that Open MPI is operating correctly (<A HREF="hello.c">hello.c</A>).
-Make sure Open MPI is in your path according to the FAQ item on <A
-HREF="https://www.open-mpi.org/faq/?category=running#adding-ompi-to-path">shell
-configuation</A>.  The compile and execution output should look like
+Make sure Open MPI is in your path according to the <A
+HREF="https://docs.open-mpi.org/en/<?php print($ompi_docs_release_branch); ?>/launching-apps/quickstart.html">quickstart
+documentation</A>.  The compile and execution output should look like
 that below.</P>
 
 <p><table width=100% border=0 cellpadding=5 cellspacing=0 class=example>

--- a/software/ompi/major-changes.php
+++ b/software/ompi/major-changes.php
@@ -114,9 +114,8 @@ certainly cause some legacy MPI applications to fail to
 compile.</strong>
 
 <p> <strong><font color="red">DO NOT FEAR!</font></strong> It is easy
-to fix such issues.  <a href="<?php print($topdir);
-?>/faq/?category=mpi-removed">See this FAQ category for more
-information</a>, including:</p>
+to fix such issues.  <a href="https://docs.open-mpi.org/">See the Open
+MPI documentation for more information</a>, including:</p>
 
 <p><ul>
     <li>How to upgrade your application to no longer use these legacy
@@ -137,20 +136,19 @@ the preferred method of InfiniBand support.
 
 <p><ul>
 
-    <li><a href="<?php print($topdir);
-    ?>/faq/?category=building#build-p2p">See this FAQ item</a> for
+    <li><a href="https://docs.open-mpi.org/">See the Open MPI
+    documentation</a> for
     information on how to build Open MPI with UCX support.</li>
 
-    <li><a href="<?php print($topdir);
-    ?>/faq/?category=openfabrics#run-ucx">See this FAQ item</a> for
+    <li><a href="https://docs.open-mpi.org/">See the Open MPI
+    documentation</a> for
     information on how to run Open MPI jobs with UCX support.</li>
 
     <li> In the Open MPI v4.0.x series, the <code>openib</code> BTL
     will still be used &mdash; by default &mdash; for RoCE and iWARP networks
     (although UCX works fine with these networks, too).  Users can
     force the use of UCX for RoCE and iWARP networks, if desired (see
-    <a href="<?php print($topdir);
-    ?>/faq/?category=openfabrics#run-ucx">this FAQ item</a>).</li>
+    <a href="https://docs.open-mpi.org/">the Open MPI documentation</a>).</li>
 
 </ul></p>
 </li>

--- a/source/building.php
+++ b/source/building.php
@@ -15,15 +15,9 @@ include_once("warning.inc");
 Instructions and requirements for building from source for other
 versions can be found here:</P>
 
-<P> <A
-HREF="https://docs.open-mpi.org/en/main/developers/index.html">Open
-MPI's <CODE>main</CODE> branch</A>
-
-<BR />
-
-<A
-HREF="https://docs.open-mpi.org/en/v5.0.x/developers/index.html">Open
-MPI's <CODE>v5.0.x</CODE> branch</A></P>
+<P><A
+HREF="https://docs.open-mpi.org/en/<?php print($ompi_docs_release_branch); ?>/developers/index.html">Open
+MPI's <CODE><?php print($ompi_docs_release_branch); ?></CODE> branch</A></P>
 
 <P>If you are looking to build branches other than what are listed
 above,<BR />go to any of the above links and then use the left-hand
@@ -161,10 +155,10 @@ row("v4.0.x", "1.4.17", "2.69", "1.15", "2.4.6", "2.5.35");
 ?>
 
 <TR>
-<TD>main</TD>
+<TD><?php print($ompi_docs_release_branch); ?> and up</TD>
 
 <TD COLSPAN="5" ALIGN="CENTER"><A
-HREF="https://docs.open-mpi.org/en/main/developers/index.html">See
+HREF="https://docs.open-mpi.org/en/<?php print($ompi_docs_release_branch); ?>/developers/index.html">See
 this documentation</A><BR /> If looking for requirements for other
 Open MPI versions (i.e., &gt;= v5.0.0),<BR />go to the above
 documentation link and use the left-hand navigation to select the

--- a/source/index.php
+++ b/source/index.php
@@ -48,10 +48,10 @@ MPI from a developer checkout.</li>
 <br>
 
 <li> <a href="<?php print("$topdir/nightly/"); ?>">Download a nightly
-snapshot tarball</a>.  Then see the <a href="<?php
-print($topdir); ?>/faq/?category=building">Building Open MPI</a>
-section of the FAQ for instructions on how to build and install
-it.<br>
+snapshot tarball</a>.  Then see the <a
+href="https://docs.open-mpi.org/en/<?php print($ompi_docs_release_branch); ?>/installing-open-mpi/">Open
+MPI installation documentation</a> for instructions on how to build and
+install it.<br>
 
 <strong><font color=green>Advantage:</font></strong> You need no
 extra tools to compile and install Open MPI.<br>

--- a/source/nav.inc
+++ b/source/nav.inc
@@ -1,8 +1,11 @@
 <?php
 include_once("$topdir/includes/nav.inc");
+include_once("$topdir/software/ompi/current/version.inc");
+
+$ompi_docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
 
 $this_dir = "source";
-$this_nav[] = new Nav("What's new?", "https://docs.open-mpi.org/en/main/news/news-main.html");
+$this_nav[] = new Nav("What's new?", "https://docs.open-mpi.org/en/$ompi_docs_release_branch/news/news-$ompi_docs_release_branch.html");
 $this_nav[] = new Nav("Git clone", "git.php");
 $this_nav[] = new Nav("Building from Git", "building.php");
 $this_nav[] = new Nav("OpenHub stats", "http://www.openhub.net/p/openmpi");


### PR DESCRIPTION
Nudge users and crawlers toward docs.open-mpi.org for current Open MPI documentation without deleting or hiding the legacy man pages hosted on this site.

Add a shared notice for legacy Open MPI man pages under /doc/current/ and the versioned /doc/v1.x through /doc/v4.x trees.  The notice marks those pages as older Open MPI documentation and links to the current release documentation branch that matches the default Open MPI download series.  Derive that release docs branch from the existing Open MPI download metadata instead of hard-coding a docs branch.

Map legacy man-page links to more specific current docs where there is a clear equivalent.  MPI section 3 API pages link to the matching current MPI API man page.  Wrapper compiler pages link to the current ompi-wrapper-compiler(1) page.  mpirun(1) and mpiexec(1) link to the current mpirun(1) page, and ompi_info(1) links to the current ompi_info(1) page.  Other legacy man pages fall back to the current Open MPI manual-page index.

Hide the local Open MPI FAQ link from the common site navigation unless the current request is already under /faq/.  This keeps normal root-traversable site chrome pointed at docs.open-mpi.org while still preserving local FAQ navigation for users who arrive at those legacy FAQ pages directly.

Update other prominent links to favor release documentation on docs.open-mpi.org.  The support redirect, version information link, source navigation news link, source build requirements page, source overview page, workshop prerequisite page, home page technical documentation link, and selected Open MPI major-changes references now point at the current release docs or at docs.open-mpi.org instead of the legacy FAQ or the docs site's main branch.