### PR TITLE
Preserve release metadata in shared header

### DIFF
--- a/includes/header.inc
+++ b/includes/header.inc
@@ -16,8 +16,28 @@ if (!isset($logo_url)) {
 if (!isset($project)) {
     $project = "Open MPI";
 }
+
+// The current Open MPI version metadata is needed for common nav links,
+// but release pages set similarly named globals before including this file.
+$ompi_header_saved_release_vars = array();
+foreach (array("release_series", "release_branch", "download_prefix", "s3_prefix",
+               "releases", "prereleases", "cygwin_note") as $var) {
+    $ompi_header_saved_release_vars[$var] = array(
+        "set" => isset($$var),
+        "value" => isset($$var) ? $$var : NULL,
+    );
+}
 include_once("$topdir/software/ompi/current/version.inc");
 $ompi_docs_release_branch = isset($release_branch) ? $release_branch : "$ver_current_dir.x";
+foreach ($ompi_header_saved_release_vars as $var => $saved) {
+    if ($saved["set"]) {
+        $$var = $saved["value"];
+    } else {
+        unset($$var);
+    }
+}
+unset($ompi_header_saved_release_vars, $var, $saved);
+
 $request_path = isset($_SERVER["REQUEST_URI"]) ?
     parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH) : "";
 if ($request_path === false) {


### PR DESCRIPTION
The common site header needs the current Open MPI release metadata so that global navigation can point at the current docs.open-mpi.org branch.  It gets that metadata by including
software/ompi/current/version.inc.

That include has a side effect: it loads the current release series version.inc, which defines generic globals such as $release_series, $release_branch, $download_prefix, $s3_prefix, $releases, $prereleases, and $cygwin_note.  Open MPI release download pages include their own series-specific version.inc before including the shared header, so the header was overwriting the page's v4.1, v4.0, and older release metadata with the current v5.0 metadata.  The page title and explanatory text were computed before the overwrite, but the download table was rendered afterward, which made older release pages show the v5.0 download table.

Save those release-related globals before including the current-version metadata, compute the header's docs branch from the current release, then restore the page's original values.  This keeps the shared nav using current docs links without clobbering the series-specific data that download pages pass to
print_release_section().